### PR TITLE
BuildBuild\build.msbuild

### DIFF
--- a/Build/Common.Build.Settings
+++ b/Build/Common.Build.Settings
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">$(MSBuildThisFileDirectory)..\</SolutionDir>
+    <Configuration Condition="'$(Configuration)'==''">Debug</Configuration>
+    <Platform Condition="'$(Platform)'==''">Win32</Platform>
+    <PlatformToolset Condition=" '$(PlatformToolset)' == ''">v120</PlatformToolset>
+    <OutputPath Condition="'$(OutputPath)' == ''">$(SolutionDir)bin\$(Platform)\$(Configuration)\</OutputPath>
+    <OutDir>$(OutputPath)</OutDir>
+  </PropertyGroup>
+</Project>

--- a/Build/Config.Definitions.Props
+++ b/Build/Config.Definitions.Props
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>

--- a/Build/SignalRClient.Build.Settings
+++ b/Build/SignalRClient.Build.Settings
@@ -1,14 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <Configuration Condition="'$(Configuration)'==''">Debug</Configuration>
-    <Platform Condition="'$(Platform)'==''">Win32</Platform>
-  </PropertyGroup>
+  <Import Project="$(MSBuildThisFileDirectory)\Common.Build.Settings" />
   <PropertyGroup>
     <SignalrClientTargetName>signalrclient</SignalrClientTargetName>
     <DownloadNuGetExe Condition=" '$(DownloadNuGetExe)' == '' ">true</DownloadNuGetExe>
     <RestorePackages>true</RestorePackages>
-    <PlatformToolset Condition=" '$(PlatformToolset)' == ''">v120</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
@@ -32,6 +28,8 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <ProgramDatabaseFile>$(OutDir)$(TargetName).pdb</ProgramDatabaseFile>
+      <StripPrivateSymbols>$(OutDir)$(TargetName).pub.pdb</StripPrivateSymbols>
     </Link>
   </ItemDefinitionGroup>
 

--- a/Build/build.msbuild
+++ b/Build/build.msbuild
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Test" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildThisFileDirectory)\Common.Build.Settings" />
+
+  <ItemGroup>
+    <Projects Include="$(SolutionDir)src\signalrclient\Build\VS2013\signalrclient.vcxproj" />
+    <Projects Include="$(SolutionDir)src\signalrclientdll\Build\VS2013\signalrclientdll.vcxproj" />
+    <Projects Include="$(SolutionDir)test\signalrclienttests\Build\VS2013\signalrclienttests.vcxproj" />
+  </ItemGroup>
+
+  <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
+
+  <Target Name="Build">
+    <MSBuild Targets="$(BuildTargets)"
+      Projects="@(Projects)"
+      Properties="Configuration=$(Configuration);Platform=$(Platform);PlatformToolset=$(PlatformToolset)" />
+  </Target>
+
+  <Target Name="Clean">
+    <MSBuild Targets="Clean"
+      Projects="@(Projects)" />
+  </Target>
+
+  <Target Name="Rebuild">
+    <MSBuild Projects="$(MSBuildProjectFile)" Properties="BuildTargets=Rebuild;Configuration=$(Configuration)" Targets="Clean;Build" />
+  </Target>
+
+  <Target Name="Test" DependsOnTargets="Build">
+    <Exec Command="$(OutDir)\signalrclienttests.exe" />
+  </Target>
+</Project>

--- a/build.cmd
+++ b/build.cmd
@@ -1,0 +1,1 @@
+msbuild "%~dp0\Build\build.msbuild" /v:minimal /maxcpucount /nodeReuse:false %*

--- a/src/signalrclient/Build/VS2013/signalrclient.vcxproj
+++ b/src/signalrclient/Build/VS2013/signalrclient.vcxproj
@@ -1,16 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\cpprestsdk.2.2.0\build\native\cpprestsdk.props" Condition="Exists('..\..\..\..\packages\cpprestsdk.2.2.0\build\native\cpprestsdk.props')" />
-  <Import Project="..\..\..\..\Build\signalrclient.build.settings" />
+  <Import Project="..\..\..\..\Build\SignalRClient.Build.Settings" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>{87ED3AD4-D820-48CD-8382-A12564213A12}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>signalr</RootNamespace>
     <ProjectName>signalrclient</ProjectName>
     <TargetName>$(SignalrClientTargetName)</TargetName>
-    <OutDir>$(SolutionDir)$(Configuration)\lib\</OutDir>
-    <IntDir>$(Configuration)\lib\</IntDir>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\..\</SolutionDir>
+    <OutDir Condition="'$(OutDir)' == ''">$(SolutionDir)$(Configuration)\</OutDir>
+    <OutDir>$(OutDir)lib\</OutDir>
+    <IntDir>$(Configuration)\lib\</IntDir>
     <ConfigurationType>StaticLibrary</ConfigurationType>
   </PropertyGroup>
   <Import Project="..\..\..\..\Build\Config.Definitions.props" />

--- a/src/signalrclientdll/Build/VS2013/signalrclientdll.vcxproj
+++ b/src/signalrclientdll/Build/VS2013/signalrclientdll.vcxproj
@@ -8,9 +8,10 @@
     <RootNamespace>signalrclient</RootNamespace>
     <ProjectName>signalrclientdll</ProjectName>
     <TargetName>$(SignalrClientTargetName)</TargetName>
-    <OutDir>$(SolutionDir)$(Configuration)\dll\</OutDir>
-    <IntDir>$(Configuration)\dll\</IntDir>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\..\</SolutionDir>
+    <OutDir Condition="'$(OutDir)' == ''">$(SolutionDir)$(Configuration)\</OutDir>
+    <OutDir>$(OutDir)dll\</OutDir>
+    <IntDir>$(Configuration)\dll\</IntDir>
     <ConfigurationType>DynamicLibrary</ConfigurationType>
   </PropertyGroup>
   <Import Project="..\..\..\..\Build\Config.Definitions.props" />

--- a/test/gtest-1.7.0/msvc/gtest.vcxproj
+++ b/test/gtest-1.7.0/msvc/gtest.vcxproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\..\Build\signalrclient.build.settings" />
+  <Import Project="..\..\..\Build\SignalRClient.Build.Settings" />
   <Import Project="..\..\..\Build\Config.Definitions.props" />
   <ItemGroup>
     <ClCompile Include="..\src\gtest-all.cc" />

--- a/test/signalrclienttests/Build/VS2013/signalrclienttests.vcxproj
+++ b/test/signalrclienttests/Build/VS2013/signalrclienttests.vcxproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\cpprestsdk.2.2.0\build\native\cpprestsdk.props" Condition="Exists('..\..\..\..\packages\cpprestsdk.2.2.0\build\native\cpprestsdk.props')" />
-  <Import Project="..\..\..\..\Build\signalrclient.build.settings" />
+  <Import Project="..\..\..\..\Build\SignalRClient.Build.Settings" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>{10376148-BCF4-4B55-98A5-3C98C87FD898}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>


### PR DESCRIPTION
Adding the build.msbuild file to enable building and running tests from command line (now) and building the NuGet package (soon).
Renaming signalrclient.build.settings -> SignalRClient.Build.Settings to follow MSBuild conventions.