### PR TITLE
itoa - changing callback id from int to string

### DIFF
--- a/src/signalrclient/callback_manager.cpp
+++ b/src/signalrclient/callback_manager.cpp
@@ -18,9 +18,9 @@ namespace signalr
     }
 
     // note: callback must not throw
-    int callback_manager::register_callback(const std::function<void(const web::json::value&)>& callback)
+    utility::string_t callback_manager::register_callback(const std::function<void(const web::json::value&)>& callback)
     {
-        auto callback_id = m_id++;
+        auto callback_id = get_callback_id();
 
         {
             std::lock_guard<std::mutex> lock(m_map_lock);
@@ -31,8 +31,9 @@ namespace signalr
         return callback_id;
     }
 
+
     // invokes a callback and stops tracking it
-    bool callback_manager::complete_callback(int callback_id, const web::json::value& arguments)
+    bool callback_manager::complete_callback(const utility::string_t& callback_id, const web::json::value& arguments)
     {
         std::function<void(const web::json::value& arguments)> callback;
 
@@ -53,6 +54,15 @@ namespace signalr
         return true;
     }
 
+    bool callback_manager::remove_callback(const utility::string_t& callback_id)
+    {
+        {
+            std::lock_guard<std::mutex> lock(m_map_lock);
+
+            return m_callbacks.erase(callback_id) != 0;
+        }
+    }
+
     void callback_manager::clear(const web::json::value& arguments)
     {
         {
@@ -65,5 +75,13 @@ namespace signalr
 
             m_callbacks.clear();
         }
+    }
+
+    utility::string_t callback_manager::get_callback_id()
+    {
+        auto callback_id = m_id++;
+        utility::stringstream_t ss;
+        ss << callback_id;
+        return ss.str();
     }
 }

--- a/src/signalrclient/callback_manager.h
+++ b/src/signalrclient/callback_manager.h
@@ -20,14 +20,17 @@ namespace signalr
         callback_manager(const callback_manager&) = delete;
         callback_manager& operator=(const callback_manager&) = delete;
 
-        int register_callback(const std::function<void(const web::json::value&)>& callback);
-        bool complete_callback(int callback_id, const web::json::value& arguments);
+        utility::string_t register_callback(const std::function<void(const web::json::value&)>& callback);
+        bool complete_callback(const utility::string_t&  callback_id, const web::json::value& arguments);
+        bool remove_callback(const utility::string_t&  callback_id);
         void clear(const web::json::value& arguments);
 
     private:
         std::atomic<int> m_id = 0;
-        std::unordered_map<int, std::function<void(const web::json::value&)>> m_callbacks;
+        std::unordered_map<utility::string_t, std::function<void(const web::json::value&)>> m_callbacks;
         std::mutex m_map_lock;
         const web::json::value m_dtor_clear_arguments;
+
+        utility::string_t get_callback_id();
     };
 }

--- a/test/signalrclienttests/callback_manager_tests.cpp
+++ b/test/signalrclienttests/callback_manager_tests.cpp
@@ -37,9 +37,34 @@ TEST(callback_manager_complete_callback, complete_callback_invokes_callback_and_
 TEST(callback_manager_complete_callback, complete_callback_returns_false_for_invalid_callback_id)
 {
     auto callback_mgr = callback_manager{ json::value::object() };
-    auto callback_found = callback_mgr.complete_callback(42, json::value::number(42));
+    auto callback_found = callback_mgr.complete_callback(_XPLATSTR("42"), json::value::object());
 
     ASSERT_FALSE(callback_found);
+}
+
+TEST(callback_manager_remove, remove_removes_callback_and_returns_true_for_valid_callback_id)
+{
+    auto callback_called = false;
+
+    {
+        auto callback_mgr = callback_manager{ json::value::object() };
+
+        auto callback_id = callback_mgr.register_callback(
+            [&callback_called](const json::value&)
+        {
+            callback_called = true;
+        });
+
+        ASSERT_TRUE(callback_mgr.remove_callback(callback_id));
+    }
+
+    ASSERT_FALSE(callback_called);
+}
+
+TEST(callback_manager_remove, remove_returns_false_for_invalid_callback_id)
+{
+    auto callback_mgr = callback_manager{ json::value::object() };
+    ASSERT_FALSE(callback_mgr.remove_callback(_XPLATSTR("42")));
 }
 
 TEST(callback_manager_clear, clear_invokes_all_callbacks)

--- a/test/signalrclienttests/hub_connection_impl_tests.cpp
+++ b/test/signalrclienttests/hub_connection_impl_tests.cpp
@@ -248,9 +248,9 @@ TEST(hub_invocation, hub_connection_invokes_discards_persistent_connection_messa
         std::string responses[]
         {
             "{\"S\":1, \"M\":[] }",
-                "{ \"C\":\"d-486F0DF9-BAO,5|BAV,1|BAW,0\", \"M\" : [{\"Name\": \"Test\"}] }",
-                "{\"C\":\"d- F430FB19\", \"M\" : [{\"H\":\"my_hub\", \"M\":\"broadcast\", \"A\" : [\"signal event\", 1]}] }",
-                "{}"
+            "{ \"C\":\"d-486F0DF9-BAO,5|BAV,1|BAW,0\", \"M\" : [{\"Name\": \"Test\"}] }",
+            "{\"C\":\"d- F430FB19\", \"M\" : [{\"H\":\"my_hub\", \"M\":\"broadcast\", \"A\" : [\"signal event\", 1]}] }",
+            "{}"
         };
 
         call_number = min(call_number + 1, 2);


### PR DESCRIPTION
Signalr uses strings for callback ids in the protocol so changing callback manager to also use strings.
Adding a method to remove callbacks.