### PR TITLE
TouchUps - tweaking API

### DIFF
--- a/include/signalrclient/connection.h
+++ b/include/signalrclient/connection.h
@@ -29,6 +29,10 @@ namespace signalr
 
         SIGNALRCLIENT_API ~connection();
 
+        connection(const connection&) = delete;
+
+        connection& operator=(const connection&) = delete;
+
         SIGNALRCLIENT_API pplx::task<void> start();
 
         SIGNALRCLIENT_API pplx::task<void> send(const utility::string_t& data);

--- a/include/signalrclient/hub_connection.h
+++ b/include/signalrclient/hub_connection.h
@@ -28,6 +28,10 @@ namespace signalr
 
         SIGNALRCLIENT_API ~hub_connection();
 
+        hub_connection(const hub_connection&) = delete;
+
+        hub_connection& operator=(const hub_connection&) = delete;
+
         SIGNALRCLIENT_API pplx::task<void> start();
         SIGNALRCLIENT_API pplx::task<void> stop();
 

--- a/include/signalrclient/hub_proxy.h
+++ b/include/signalrclient/hub_proxy.h
@@ -21,6 +21,9 @@ namespace signalr
     {
     public:
         explicit hub_proxy(const std::shared_ptr<internal_hub_proxy>& proxy);
+
+        SIGNALRCLIENT_API hub_proxy();
+
         SIGNALRCLIENT_API ~hub_proxy();
 
         SIGNALRCLIENT_API utility::string_t get_hub_name() const;
@@ -56,6 +59,9 @@ namespace signalr
         {
             return invoke_void(method_name, arguments, on_progress);
         }
+
+        SIGNALRCLIENT_API hub_proxy& operator=(const hub_proxy& other);
+        SIGNALRCLIENT_API hub_proxy& operator=(const hub_proxy&& other);
 
     private:
         std::shared_ptr<internal_hub_proxy> m_pImpl;

--- a/src/signalrclient/hub_proxy.cpp
+++ b/src/signalrclient/hub_proxy.cpp
@@ -7,6 +7,9 @@
 
 namespace signalr
 {
+    hub_proxy::hub_proxy()
+    { }
+
     hub_proxy::hub_proxy(const std::shared_ptr<internal_hub_proxy>& proxy)
         : m_pImpl(proxy)
     { }
@@ -17,23 +20,63 @@ namespace signalr
 
     utility::string_t hub_proxy::get_hub_name() const
     {
+        if (!m_pImpl)
+        {
+            throw std::runtime_error("get_hub_name() cannot be called on uninitialized hub_proxy instance");
+        }
+
         return m_pImpl->get_hub_name();
     }
 
     void hub_proxy::on(const utility::string_t& event_name, const std::function<void(const web::json::value &)>& handler)
     {
+        if (!m_pImpl)
+        {
+            throw std::runtime_error("on() cannot be called on uninitialized hub_proxy instance");
+        }
+
         return m_pImpl->on(event_name, handler);
     }
 
     pplx::task<web::json::value> hub_proxy::invoke_json(const utility::string_t& method_name, const web::json::value& arguments,
         const std::function<void(const web::json::value&)>& on_progress)
     {
+        if (!m_pImpl)
+        {
+            throw std::runtime_error("invoke() cannot be called on uninitialized hub_proxy instance");
+        }
+
         return m_pImpl->invoke_json(method_name, arguments, on_progress);
     }
 
     pplx::task<void> hub_proxy::invoke_void(const utility::string_t& method_name, const web::json::value& arguments,
         const std::function<void(const web::json::value&)>& on_progress)
     {
+        if (!m_pImpl)
+        {
+            throw std::runtime_error("invoke() cannot be called on uninitialized hub_proxy instance");
+        }
+
         return m_pImpl->invoke_void(method_name, arguments, on_progress);
+    }
+
+    hub_proxy& hub_proxy::operator=(const hub_proxy& other)
+    {
+        if (this != &other)
+        {
+            m_pImpl = other.m_pImpl;
+        }
+
+        return *this;
+    }
+
+    hub_proxy& hub_proxy::operator=(const hub_proxy&& other)
+    {
+        if (this != &other)
+        {
+            m_pImpl = std::move(other.m_pImpl);
+        }
+
+        return *this;
     }
 }


### PR DESCRIPTION
- adding a public parameterless ctor to the `hub_proxy` class
- blocking passing `hub_connection` and `connection` instances by value to prevent from creating cycles where a `hub_connection` or `connection` instance is captured by value in a callback stored in the very same `hub_connection` or `connection` instance