### PR TITLE
LatestAndGreatest - moving to casablanca 2.4.0.1

### DIFF
--- a/NuGet/signalrclientcpp.nuspec
+++ b/NuGet/signalrclientcpp.nuspec
@@ -18,7 +18,7 @@
     <tags>Microsoft AspNet SignalR AspNetSignalR Client C++</tags>
     <releaseNotes>https://github.com/SignalR/SignalR/releases</releaseNotes>
     <dependencies>
-      <dependency id="cpprestsdk" version="2.2.0" />
+      <dependency id="cpprestsdk" version="2.4.0.1" />
     </dependencies>
   </metadata>
 </package>

--- a/include/signalrclient/connection.h
+++ b/include/signalrclient/connection.h
@@ -6,14 +6,12 @@
 #include "_exports.h"
 #include <memory>
 #include <functional>
-#include <ppltasks.h>
+#include "pplx\pplxtasks.h"
 #include "connection_state.h"
 #include "trace_level.h"
 #include "log_writer.h"
 #include "trace_log_writer.h"
 #include <unordered_map>
-
-namespace pplx = concurrency;
 
 namespace signalr
 {

--- a/include/signalrclient/hub_connection.h
+++ b/include/signalrclient/hub_connection.h
@@ -6,15 +6,13 @@
 #include "_exports.h"
 #include <memory>
 #include <functional>
-#include <ppltasks.h>
-#include <cpprest\json.h>
+#include "pplx\pplxtasks.h"
+#include "cpprest\json.h"
 #include "connection_state.h"
 #include "trace_level.h"
 #include "log_writer.h"
 #include "trace_log_writer.h"
 #include "hub_proxy.h"
-
-namespace pplx = concurrency;
 
 namespace signalr
 {

--- a/include/signalrclient/hub_exception.h
+++ b/include/signalrclient/hub_exception.h
@@ -4,9 +4,9 @@
 #pragma once
 
 #include <stdexcept>
-#include <cpprest\basic_types.h>
-#include <cpprest\json.h>
-#include <cpprest\asyncrt_utils.h>
+#include "cpprest\details\basic_types.h"
+#include "cpprest\json.h"
+#include "cpprest\asyncrt_utils.h"
 
 namespace signalr
 {

--- a/include/signalrclient/hub_proxy.h
+++ b/include/signalrclient/hub_proxy.h
@@ -7,11 +7,9 @@
 #include <memory>
 #include <memory>
 #include <functional>
-#include <ppltasks.h>
-#include <cpprest\basic_types.h>
-#include <cpprest\json.h>
-
-namespace pplx = concurrency;
+#include "pplx\pplxtasks.h"
+#include "cpprest\details\basic_types.h"
+#include "cpprest\json.h"
 
 namespace signalr
 {

--- a/include/signalrclient/log_writer.h
+++ b/include/signalrclient/log_writer.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "_exports.h"
-#include <cpprest\basic_types.h>
+#include "cpprest\details\basic_types.h"
 
 namespace signalr
 {

--- a/include/signalrclient/trace_log_writer.h
+++ b/include/signalrclient/trace_log_writer.h
@@ -5,7 +5,7 @@
 
 #include "log_writer.h"
 
-#ifdef _MS_WINDOWS
+#ifdef _WIN32
 #include <Windows.h>
 #include <WinBase.h>
 #endif
@@ -17,7 +17,7 @@ namespace signalr
     public:
         void write(const utility::string_t &entry) override
         {
-#ifdef _MS_WINDOWS
+#ifdef _WIN32
             // OutputDebugString is thread safe
             OutputDebugString(entry.c_str());
 #else

--- a/include/signalrclient/web_exception.h
+++ b/include/signalrclient/web_exception.h
@@ -4,8 +4,8 @@
 #pragma once
 
 #include <stdexcept>
-#include <cpprest\basic_types.h>
-#include <cpprest\asyncrt_utils.h>
+#include "cpprest\details\basic_types.h"
+#include "cpprest\asyncrt_utils.h"
 
 namespace signalr
 {

--- a/src/signalrclient/Build/VS2013/packages.config
+++ b/src/signalrclient/Build/VS2013/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="cpprestsdk" version="2.2.0" targetFramework="Native" />
+  <package id="cpprestsdk" version="2.4.0.1" targetFramework="Native" />
 </packages>

--- a/src/signalrclient/Build/VS2013/signalrclient.vcxproj
+++ b/src/signalrclient/Build/VS2013/signalrclient.vcxproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\..\..\packages\cpprestsdk.2.2.0\build\native\cpprestsdk.props" Condition="Exists('..\..\..\..\packages\cpprestsdk.2.2.0\build\native\cpprestsdk.props')" />
+  <Import Project="..\..\..\..\packages\cpprestsdk.2.4.0.1\build\native\cpprestsdk.props" Condition="Exists('..\..\..\..\packages\cpprestsdk.2.4.0.1\build\native\cpprestsdk.props')" />
   <Import Project="..\..\..\..\Build\SignalRClient.Build.Settings" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>{87ED3AD4-D820-48CD-8382-A12564213A12}</ProjectGuid>
@@ -19,7 +19,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   <PropertyGroup Label="UserMacros">
-    <NuGetPackageImportStamp>f5ba73ec</NuGetPackageImportStamp>
+    <NuGetPackageImportStamp>0f42465d</NuGetPackageImportStamp>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
@@ -87,15 +87,15 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\..\..\..\packages\cpprestsdk.2.2.0\build\native\cpprestsdk.targets" Condition="Exists('..\..\..\..\packages\cpprestsdk.2.2.0\build\native\cpprestsdk.targets')" />
     <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+    <Import Project="..\..\..\..\packages\cpprestsdk.2.4.0.1\build\native\cpprestsdk.targets" Condition="Exists('..\..\..\..\packages\cpprestsdk.2.4.0.1\build\native\cpprestsdk.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\cpprestsdk.2.2.0\build\native\cpprestsdk.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\cpprestsdk.2.2.0\build\native\cpprestsdk.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\cpprestsdk.2.2.0\build\native\cpprestsdk.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\cpprestsdk.2.2.0\build\native\cpprestsdk.targets'))" />
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+    <Error Condition="!Exists('..\..\..\..\packages\cpprestsdk.2.4.0.1\build\native\cpprestsdk.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\cpprestsdk.2.4.0.1\build\native\cpprestsdk.props'))" />
+    <Error Condition="!Exists('..\..\..\..\packages\cpprestsdk.2.4.0.1\build\native\cpprestsdk.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\cpprestsdk.2.4.0.1\build\native\cpprestsdk.targets'))" />
   </Target>
 </Project>

--- a/src/signalrclient/Build/VS2013/signalrclient.vcxproj.filters
+++ b/src/signalrclient/Build/VS2013/signalrclient.vcxproj.filters
@@ -107,7 +107,7 @@
     </ClInclude>
     <ClInclude Include="..\..\..\..\include\signalrclient\hub_proxy.h">
       <Filter>Header Files</Filter>
-    </ClInclude>  
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\stdafx.cpp">

--- a/src/signalrclient/callback_manager.h
+++ b/src/signalrclient/callback_manager.h
@@ -3,11 +3,11 @@
 
 #pragma once
 
-#include<atomic>
-#include<unordered_map>
-#include<functional>
-#include<mutex>
-#include<cpprest\json.h>
+#include <atomic>
+#include <unordered_map>
+#include <functional>
+#include <mutex>
+#include "cpprest\json.h"
 
 namespace signalr
 {

--- a/src/signalrclient/connection_impl.cpp
+++ b/src/signalrclient/connection_impl.cpp
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 #include "stdafx.h"
-#include <cpprest\asyncrt_utils.h>
+#include "cpprest\asyncrt_utils.h"
 #include <thread>
 #include "connection_impl.h"
 #include "request_sender.h"

--- a/src/signalrclient/connection_impl.h
+++ b/src/signalrclient/connection_impl.h
@@ -5,7 +5,7 @@
 
 #include <atomic>
 #include <mutex>
-#include <cpprest\http_client.h>
+#include "cpprest\http_client.h"
 #include "signalrclient\trace_level.h"
 #include "signalrclient\connection_state.h"
 #include "web_request_factory.h"

--- a/src/signalrclient/constants.h
+++ b/src/signalrclient/constants.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "cpprest\basic_types.h"
+#include "cpprest\details\basic_types.h"
 
 #define SIGNALR_VERSION _XPLATSTR("3.0.0")
 #define PROTOCOL _XPLATSTR("1.4")

--- a/src/signalrclient/default_websocket_client.h
+++ b/src/signalrclient/default_websocket_client.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include <unordered_map>
-#include <cpprest\ws_client.h>
+#include "cpprest\ws_client.h"
 #include "websocket_client.h"
 
 using namespace web::experimental;

--- a/src/signalrclient/http_sender.cpp
+++ b/src/signalrclient/http_sender.cpp
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 #include "stdafx.h"
-#include <cpprest\http_client.h>
+#include "cpprest\http_client.h"
 #include "signalrclient\web_exception.h"
 #include "web_request_factory.h"
 #include "constants.h"

--- a/src/signalrclient/http_sender.h
+++ b/src/signalrclient/http_sender.h
@@ -3,11 +3,9 @@
 
 #pragma once
 
-#include <ppl.h>
-#include <cpprest\basic_types.h>
+#include "pplx\pplxtasks.h"
+#include "cpprest\details\basic_types.h"
 #include "web_request_factory.h"
-
-namespace pplx = concurrency;
 
 namespace signalr
 {

--- a/src/signalrclient/hub_connection_impl.h
+++ b/src/signalrclient/hub_connection_impl.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include <unordered_map>
-#include <cpprest\basic_types.h>
+#include "cpprest\details\basic_types.h"
 #include "connection_impl.h"
 #include "internal_hub_proxy.h"
 #include "callback_manager.h"

--- a/src/signalrclient/internal_hub_proxy.h
+++ b/src/signalrclient/internal_hub_proxy.h
@@ -3,8 +3,8 @@
 
 #pragma once
 #include <functional>
-#include <cpprest\basic_types.h>
-#include <cpprest\json.h>
+#include "cpprest\details\basic_types.h"
+#include "cpprest\json.h"
 #include "logger.h"
 
 using namespace web;

--- a/src/signalrclient/logger.cpp
+++ b/src/signalrclient/logger.cpp
@@ -3,7 +3,7 @@
 
 #include "stdafx.h"
 #include "logger.h"
-#include <cpprest\asyncrt_utils.h>
+#include "cpprest\asyncrt_utils.h"
 #include <iomanip>
 
 namespace signalr

--- a/src/signalrclient/negotiation_response.h
+++ b/src/signalrclient/negotiation_response.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <cpprest\basic_types.h>
+#include "cpprest\details\basic_types.h"
 
 namespace signalr
 {

--- a/src/signalrclient/request_sender.h
+++ b/src/signalrclient/request_sender.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <cpprest\base_uri.h>
+#include "cpprest\base_uri.h"
 #include "signalrclient\transport_type.h"
 #include "web_request_factory.h"
 #include "negotiation_response.h"

--- a/src/signalrclient/transport.h
+++ b/src/signalrclient/transport.h
@@ -3,12 +3,10 @@
 
 #pragma once;
 
-#include <cpprest\base_uri.h>
-#include <ppl.h>
+#include "pplx\pplxtasks.h"
+#include "cpprest\base_uri.h"
 #include "signalrclient\transport_type.h"
 #include "logger.h"
-
-namespace pplx = Concurrency;
 
 namespace signalr
 {

--- a/src/signalrclient/url_builder.cpp
+++ b/src/signalrclient/url_builder.cpp
@@ -3,7 +3,7 @@
 
 #include "stdafx.h"
 #include "constants.h"
-#include <cpprest\http_client.h>
+#include "cpprest\http_client.h"
 #include "signalrclient\transport_type.h"
 
 namespace signalr

--- a/src/signalrclient/url_builder.h
+++ b/src/signalrclient/url_builder.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <cpprest\http_client.h>
+#include "cpprest\http_client.h"
 #include "signalrclient\transport_type.h"
 
 namespace signalr

--- a/src/signalrclient/web_request.cpp
+++ b/src/signalrclient/web_request.cpp
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 #include "stdafx.h"
-#include <cpprest\http_client.h>
+#include "cpprest\http_client.h"
 #include "web_request.h"
 
 namespace signalr

--- a/src/signalrclient/web_request.h
+++ b/src/signalrclient/web_request.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "web_response.h"
-#include <cpprest\http_msg.h>
+#include "cpprest\http_msg.h"
 #include <unordered_map>
 
 namespace signalr

--- a/src/signalrclient/web_request_factory.h
+++ b/src/signalrclient/web_request_factory.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <cpprest\base_uri.h>
+#include "cpprest\base_uri.h"
 #include "web_request.h"
 
 namespace signalr

--- a/src/signalrclient/web_response.h
+++ b/src/signalrclient/web_response.h
@@ -3,10 +3,8 @@
 
 #pragma once
 
-#include <ppltasks.h>
-#include <cpprest\basic_types.h>
-
-namespace pplx = Concurrency;
+#include "pplx\pplxtasks.h"
+#include "cpprest\details\basic_types.h"
 
 namespace signalr
 {

--- a/src/signalrclient/websocket_client.h
+++ b/src/signalrclient/websocket_client.h
@@ -3,10 +3,8 @@
 
 #pragma once
 
-#include <ppl.h>
-#include <cpprest\base_uri.h>
-
-namespace pplx = concurrency;
+#include "pplx\pplxtasks.h"
+#include "cpprest\base_uri.h"
 
 namespace signalr
 {

--- a/src/signalrclient/websocket_transport.h
+++ b/src/signalrclient/websocket_transport.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <cpprest\ws_client.h>
+#include "cpprest\ws_client.h"
 #include "url_builder.h"
 #include "transport.h"
 #include "logger.h"

--- a/src/signalrclientdll/Build/VS2013/packages.config
+++ b/src/signalrclientdll/Build/VS2013/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="cpprestsdk" version="2.2.0" targetFramework="Native" />
+  <package id="cpprestsdk" version="2.4.0.1" targetFramework="Native" />
 </packages>

--- a/src/signalrclientdll/Build/VS2013/signalrclientdll.vcxproj
+++ b/src/signalrclientdll/Build/VS2013/signalrclientdll.vcxproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\..\..\packages\cpprestsdk.2.2.0\build\native\cpprestsdk.props" Condition="Exists('..\..\..\..\packages\cpprestsdk.2.2.0\build\native\cpprestsdk.props')" />
+  <Import Project="..\..\..\..\packages\cpprestsdk.2.4.0.1\build\native\cpprestsdk.props" Condition="Exists('..\..\..\..\packages\cpprestsdk.2.4.0.1\build\native\cpprestsdk.props')" />
   <Import Project="..\..\..\..\Build\SignalRClient.Build.Settings" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>{18377AE8-E372-40CE-94FD-7F65008D39A3}</ProjectGuid>
@@ -19,7 +19,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   <PropertyGroup Label="UserMacros">
-    <NuGetPackageImportStamp>39f37add</NuGetPackageImportStamp>
+    <NuGetPackageImportStamp>a7658894</NuGetPackageImportStamp>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
@@ -84,7 +84,8 @@
     <ClCompile Include="..\..\..\signalrclient\web_request_factory.cpp" />
     <ClCompile Include="..\..\dllmain.cpp">
       <CompileAsManaged>false</CompileAsManaged>
-      <PrecompiledHeader></PrecompiledHeader>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -93,14 +94,14 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
-    <Import Project="..\..\..\..\packages\cpprestsdk.2.2.0\build\native\cpprestsdk.targets" Condition="Exists('..\..\..\..\packages\cpprestsdk.2.2.0\build\native\cpprestsdk.targets')" />
+    <Import Project="..\..\..\..\packages\cpprestsdk.2.4.0.1\build\native\cpprestsdk.targets" Condition="Exists('..\..\..\..\packages\cpprestsdk.2.4.0.1\build\native\cpprestsdk.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\cpprestsdk.2.2.0\build\native\cpprestsdk.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\cpprestsdk.2.2.0\build\native\cpprestsdk.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\cpprestsdk.2.2.0\build\native\cpprestsdk.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\cpprestsdk.2.2.0\build\native\cpprestsdk.targets'))" />
+    <Error Condition="!Exists('..\..\..\..\packages\cpprestsdk.2.4.0.1\build\native\cpprestsdk.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\cpprestsdk.2.4.0.1\build\native\cpprestsdk.props'))" />
+    <Error Condition="!Exists('..\..\..\..\packages\cpprestsdk.2.4.0.1\build\native\cpprestsdk.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\cpprestsdk.2.4.0.1\build\native\cpprestsdk.targets'))" />
   </Target>
 </Project>

--- a/src/signalrclientdll/Build/VS2013/signalrclientdll.vcxproj.filters
+++ b/src/signalrclientdll/Build/VS2013/signalrclientdll.vcxproj.filters
@@ -116,9 +116,6 @@
     <ClCompile Include="..\..\dllmain.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClInclude Include="..\..\..\signalrclient\callback_manager.cpp">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClCompile Include="..\..\..\signalrclient\connection.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -168,6 +165,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\signalrclient\hub_proxy.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\signalrclient\callback_manager.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/test/signalrclienttests/Build/VS2013/packages.config
+++ b/test/signalrclienttests/Build/VS2013/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="cpprestsdk" version="2.2.0" targetFramework="Native" />
+  <package id="cpprestsdk" version="2.4.0.1" targetFramework="Native" />
 </packages>

--- a/test/signalrclienttests/Build/VS2013/signalrclienttests.vcxproj
+++ b/test/signalrclienttests/Build/VS2013/signalrclienttests.vcxproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\..\..\packages\cpprestsdk.2.2.0\build\native\cpprestsdk.props" Condition="Exists('..\..\..\..\packages\cpprestsdk.2.2.0\build\native\cpprestsdk.props')" />
+  <Import Project="..\..\..\..\packages\cpprestsdk.2.4.0.1\build\native\cpprestsdk.props" Condition="Exists('..\..\..\..\packages\cpprestsdk.2.4.0.1\build\native\cpprestsdk.props')" />
   <Import Project="..\..\..\..\Build\SignalRClient.Build.Settings" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>{10376148-BCF4-4B55-98A5-3C98C87FD898}</ProjectGuid>
@@ -15,7 +15,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   <PropertyGroup Label="UserMacros">
-    <NuGetPackageImportStamp>c5b4c4ae</NuGetPackageImportStamp>
+    <NuGetPackageImportStamp>e4937635</NuGetPackageImportStamp>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
@@ -72,15 +72,15 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\..\..\..\packages\cpprestsdk.2.2.0\build\native\cpprestsdk.targets" Condition="Exists('..\..\..\..\packages\cpprestsdk.2.2.0\build\native\cpprestsdk.targets')" />
     <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+    <Import Project="..\..\..\..\packages\cpprestsdk.2.4.0.1\build\native\cpprestsdk.targets" Condition="Exists('..\..\..\..\packages\cpprestsdk.2.4.0.1\build\native\cpprestsdk.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\cpprestsdk.2.2.0\build\native\cpprestsdk.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\cpprestsdk.2.2.0\build\native\cpprestsdk.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\cpprestsdk.2.2.0\build\native\cpprestsdk.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\cpprestsdk.2.2.0\build\native\cpprestsdk.targets'))" />
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+    <Error Condition="!Exists('..\..\..\..\packages\cpprestsdk.2.4.0.1\build\native\cpprestsdk.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\cpprestsdk.2.4.0.1\build\native\cpprestsdk.props'))" />
+    <Error Condition="!Exists('..\..\..\..\packages\cpprestsdk.2.4.0.1\build\native\cpprestsdk.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\cpprestsdk.2.4.0.1\build\native\cpprestsdk.targets'))" />
   </Target>
 </Project>

--- a/test/signalrclienttests/connection_impl_tests.cpp
+++ b/test/signalrclienttests/connection_impl_tests.cpp
@@ -10,7 +10,7 @@
 #include "signalrclient\trace_level.h"
 #include "signalrclient\trace_log_writer.h"
 #include "memory_log_writer.h"
-#include <cpprest\ws_client.h>
+#include "cpprest\ws_client.h"
 
 using namespace signalr;
 using namespace web::experimental;
@@ -424,7 +424,7 @@ TEST(connection_impl_set_message_received, callback_invoked_when_message_receive
             "{}"
         };
 
-        call_number = min(call_number + 1, 3);
+        call_number = std::min(call_number + 1, 3);
 
         return pplx::task_from_result(responses[call_number]);
     });
@@ -467,7 +467,7 @@ TEST(connection_impl_set_message_received, exception_from_callback_caught_and_lo
             "{}"
         };
 
-        call_number = min(call_number + 1, 3);
+        call_number = std::min(call_number + 1, 3);
 
         return pplx::task_from_result(responses[call_number]);
     });
@@ -513,7 +513,7 @@ TEST(connection_impl_set_message_received, non_std_exception_from_callback_caugh
             "{}"
         };
 
-        call_number = min(call_number + 1, 3);
+        call_number = std::min(call_number + 1, 3);
 
         return pplx::task_from_result(responses[call_number]);
     });
@@ -560,7 +560,7 @@ TEST(connection_impl_set_message_received, error_logged_for_malformed_payload)
             "{}"
         };
 
-        call_number = min(call_number + 1, 3);
+        call_number = std::min(call_number + 1, 3);
 
         return pplx::task_from_result(responses[call_number]);
     });
@@ -600,7 +600,7 @@ TEST(connection_impl_set_message_received, unexpected_responses_logged)
             "{}"
         };
 
-        call_number = min(call_number + 1, 3);
+        call_number = std::min(call_number + 1, 3);
 
         return pplx::task_from_result(responses[call_number]);
     });

--- a/test/signalrclienttests/http_sender_tests.cpp
+++ b/test/signalrclienttests/http_sender_tests.cpp
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 #include "stdafx.h"
-#include <cpprest\basic_types.h>
-#include <cpprest\asyncrt_utils.h>
+#include "cpprest\details\basic_types.h"
+#include "cpprest\asyncrt_utils.h"
 #include "signalrclient\web_exception.h"
 #include "http_sender.h"
 #include "web_request_stub.h"

--- a/test/signalrclienttests/hub_connection_impl_tests.cpp
+++ b/test/signalrclienttests/hub_connection_impl_tests.cpp
@@ -253,7 +253,7 @@ TEST(hub_invocation, hub_connection_invokes_users_code_on_hub_invocations)
             "{}"
         };
 
-        call_number = min(call_number + 1, 2);
+        call_number = std::min(call_number + 1, 2);
 
         return pplx::task_from_result(responses[call_number]);
     });
@@ -289,7 +289,7 @@ TEST(hub_invocation, hub_connection_discards_persistent_connection_message_primi
             "{}"
         };
 
-        call_number = min(call_number + 1, 2);
+        call_number = std::min(call_number + 1, 2);
 
         return pplx::task_from_result(responses[call_number]);
     });
@@ -329,7 +329,7 @@ TEST(hub_invocation, hub_connection_invokes_persistent_connection_message_object
             "{}"
         };
 
-        call_number = min(call_number + 1, 2);
+        call_number = std::min(call_number + 1, 2);
 
         return pplx::task_from_result(responses[call_number]);
     });
@@ -423,7 +423,7 @@ TEST(hub_invocation, hub_connection_logs_if_no_hub_for_invocation)
             "{}"
         };
 
-        call_number = min(call_number + 1, 2);
+        call_number = std::min(call_number + 1, 2);
 
         if (call_number == 2)
         {
@@ -462,7 +462,7 @@ TEST(invoke_json, invoke_returns_value_returned_from_the_server)
             "{}"
         };
 
-        call_number = min(call_number + 1, 2);
+        call_number = std::min(call_number + 1, 2);
 
         if (call_number > 0)
         {
@@ -499,7 +499,7 @@ TEST(invoke_json, invoke_propagates_errors_from_server_as_exceptions)
             "{}"
         };
 
-        call_number = min(call_number + 1, 2);
+        call_number = std::min(call_number + 1, 2);
 
         if (call_number > 0)
         {
@@ -543,7 +543,7 @@ TEST(invoke_json, invoke_propagates_hub_errors_from_server_as_hub_exceptions)
             "{}"
         };
 
-        call_number = min(call_number + 1, 2);
+        call_number = std::min(call_number + 1, 2);
 
         if (call_number > 0)
         {
@@ -590,7 +590,7 @@ TEST(progress, progress_callback_called_for_progress_messages_json)
             "{}"
         };
 
-        call_number = min(call_number + 1, 4);
+        call_number = std::min(call_number + 1, 4);
 
         if (call_number > 0)
         {
@@ -634,7 +634,7 @@ TEST(invoke_void, invoke_unblocks_task_when_server_completes_call)
             "{}"
         };
 
-        call_number = min(call_number + 1, 2);
+        call_number = std::min(call_number + 1, 2);
 
         if (call_number > 0)
         {
@@ -672,7 +672,7 @@ TEST(invoke_void, invoke_logs_if_callback_for_given_id_not_found)
             "{}"
         };
 
-        call_number = min(call_number + 1, 2);
+        call_number = std::min(call_number + 1, 2);
 
         if (call_number > 1)
         {
@@ -710,7 +710,7 @@ TEST(invoke_void, invoke_propagates_errors_from_server_as_exceptions)
             "{}"
         };
 
-        call_number = min(call_number + 1, 2);
+        call_number = std::min(call_number + 1, 2);
 
         if (call_number > 0)
         {
@@ -754,7 +754,7 @@ TEST(invoke_void, invoke_propagates_hub_errors_from_server_as_hub_exceptions)
             "{}"
         };
 
-        call_number = min(call_number + 1, 2);
+        call_number = std::min(call_number + 1, 2);
 
         if (call_number > 0)
         {
@@ -799,7 +799,7 @@ TEST(invoke_void, invoke_creates_hub_exception_even_if_no_error_data)
             "{}"
         };
 
-        call_number = min(call_number + 1, 2);
+        call_number = std::min(call_number + 1, 2);
 
         if (call_number > 0)
         {
@@ -844,7 +844,7 @@ TEST(invoke_void, invoke_creates_runtime_error_even_hub_exception_indicator_fals
             "{}"
         };
 
-        call_number = min(call_number + 1, 2);
+        call_number = std::min(call_number + 1, 2);
 
         if (call_number > 0)
         {
@@ -889,7 +889,7 @@ TEST(invoke_void, invoke_creates_runtime_error_even_hub_exception_indicator_non_
             "{}"
         };
 
-        call_number = min(call_number + 1, 2);
+        call_number = std::min(call_number + 1, 2);
 
         if (call_number > 0)
         {
@@ -936,7 +936,7 @@ TEST(progress, progress_callback_called_for_progress_messages)
             "{}"
         };
 
-        call_number = min(call_number + 1, 4);
+        call_number = std::min(call_number + 1, 4);
 
         if (call_number > 0)
         {
@@ -981,7 +981,7 @@ TEST(progress, exceptions_from_progress_callbacks_logged)
             "{}"
         };
 
-        call_number = min(call_number + 1, 3);
+        call_number = std::min(call_number + 1, 3);
 
         if (call_number > 0)
         {

--- a/test/signalrclienttests/logger_tests.cpp
+++ b/test/signalrclienttests/logger_tests.cpp
@@ -3,7 +3,7 @@
 
 #include "stdafx.h"
 #include "test_utils.h"
-#include <cpprest\asyncrt_utils.h>
+#include "cpprest\asyncrt_utils.h"
 #include "signalrclient\trace_log_writer.h"
 #include "logger.h"
 #include "memory_log_writer.h"

--- a/test/signalrclienttests/request_sender_tests.cpp
+++ b/test/signalrclienttests/request_sender_tests.cpp
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 #include "stdafx.h"
-#include <cpprest\basic_types.h>
+#include "cpprest\details\basic_types.h"
 #include "signalrclient\web_exception.h"
 #include "request_sender.h"
 #include "web_request_stub.h"

--- a/test/signalrclienttests/stdafx.h
+++ b/test/signalrclienttests/stdafx.h
@@ -3,6 +3,11 @@
 
 #pragma once
 
+#ifdef _WIN32
+// prevents from defining min/max macros that conflict with std::min()/std::max() functions
+#define NOMINMAX
+#endif
+
 #include "targetver.h"
 
 #include <stdio.h>

--- a/test/signalrclienttests/test_utils.h
+++ b/test/signalrclienttests/test_utils.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <cpprest\basic_types.h>
+#include "cpprest\details\basic_types.h"
 #include "websocket_client.h"
 #include "web_request_factory.h"
 

--- a/test/signalrclienttests/web_request_tests.cpp
+++ b/test/signalrclienttests/web_request_tests.cpp
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 #include "stdafx.h"
-#include <cpprest\http_listener.h>
+#include "cpprest\http_listener.h"
 #include "web_request.h"
 
 using namespace web;


### PR DESCRIPTION
Reasons:
- secure websockets apparently did not work correctly in 2.2.0
- 2.4.0.1 has v140 compatible binaries we will need

Other changes:
- using headers installed with NuGet package and not with VS
- enforcing using the `std::min` function istead of the `min` macro defined only in a windows header file