### PR TITLE
SpeedyCrossPlatformer - fixing stdafx.

### DIFF
--- a/include/signalrclient/trace_log_writer.h
+++ b/include/signalrclient/trace_log_writer.h
@@ -5,31 +5,11 @@
 
 #include "log_writer.h"
 
-#ifdef _WIN32
-#include <Windows.h>
-#include <WinBase.h>
-#endif
-
 namespace signalr
 {
     class trace_log_writer : public log_writer
     {
     public:
-        void write(const utility::string_t &entry) override
-        {
-#ifdef _WIN32
-            // OutputDebugString is thread safe
-            OutputDebugString(entry.c_str());
-#else
-            // TODO: XPLAT - there is no data race for standard output streams in C++ 11 but the results
-            // might be garbled when the method is called concurrently from multiple threads
-#ifdef _UTF16_STRINGS
-            std::wclog << entry;
-#else
-            std::clog << entry;
-#endif  // _UTF16_STRINGS
-
-#endif  // _MS_WINDOWS
-        }
+        void write(const utility::string_t &entry) override;
     };
 }

--- a/src/signalrclient/Build/VS2013/signalrclient.vcxproj
+++ b/src/signalrclient/Build/VS2013/signalrclient.vcxproj
@@ -50,7 +50,6 @@
     <ClInclude Include="..\..\negotiation_response.h" />
     <ClInclude Include="..\..\request_sender.h" />
     <ClInclude Include="..\..\stdafx.h" />
-    <ClInclude Include="..\..\targetver.h" />
     <ClInclude Include="..\..\transport.h" />
     <ClInclude Include="..\..\transport_factory.h" />
     <ClInclude Include="..\..\url_builder.h" />
@@ -74,6 +73,7 @@
     <ClCompile Include="..\..\stdafx.cpp">
       <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="..\..\trace_log_writer.cpp" />
     <ClCompile Include="..\..\transport.cpp" />
     <ClCompile Include="..\..\transport_factory.cpp" />
     <ClCompile Include="..\..\url_builder.cpp" />

--- a/src/signalrclient/Build/VS2013/signalrclient.vcxproj.filters
+++ b/src/signalrclient/Build/VS2013/signalrclient.vcxproj.filters
@@ -18,9 +18,6 @@
     <ClInclude Include="..\..\stdafx.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\targetver.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\..\..\include\signalrclient\connection.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -162,6 +159,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\hub_proxy.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\trace_log_writer.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/src/signalrclient/stdafx.h
+++ b/src/signalrclient/stdafx.h
@@ -3,8 +3,18 @@
 
 #pragma once
 
-#include "targetver.h"
+#ifdef _WIN32 // used in the default log writer and to build the dll
+
+#include <SDKDDKVer.h>
 
 #define WIN32_LEAN_AND_MEAN
 
 #include <windows.h>
+
+#endif
+
+#include <functional>
+#include <unordered_map>
+#include "cpprest/details/basic_types.h"
+#include "cpprest/json.h"
+#include "pplx/pplxtasks.h"

--- a/src/signalrclient/targetver.h
+++ b/src/signalrclient/targetver.h
@@ -1,6 +1,0 @@
-// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
-
-#pragma once
-
-#include <SDKDDKVer.h>

--- a/src/signalrclient/trace_log_writer.cpp
+++ b/src/signalrclient/trace_log_writer.cpp
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#include "stdafx.h"
+#include "signalrclient/trace_log_writer.h"
+
+namespace signalr
+{
+    void trace_log_writer::write(const utility::string_t &entry)
+    {
+#ifdef _WIN32
+        // OutputDebugString is thread safe
+        OutputDebugString(entry.c_str());
+#else
+        // TODO: XPLAT - there is no data race for standard output streams in C++ 11 but the results
+        // might be garbled when the method is called concurrently from multiple threads
+#ifdef _UTF16_STRINGS
+        std::wclog << entry;
+#else
+        std::clog << entry;
+#endif  // _UTF16_STRINGS
+
+#endif  // _MS_WINDOWS
+    }
+}

--- a/src/signalrclientdll/Build/VS2013/signalrclientdll.vcxproj
+++ b/src/signalrclientdll/Build/VS2013/signalrclientdll.vcxproj
@@ -50,7 +50,6 @@
     <ClInclude Include="..\..\..\signalrclient\negotiation_response.h" />
     <ClInclude Include="..\..\..\signalrclient\request_sender.h" />
     <ClInclude Include="..\..\..\signalrclient\stdafx.h" />
-    <ClInclude Include="..\..\..\signalrclient\targetver.h" />
     <ClInclude Include="..\..\..\signalrclient\transport.h" />
     <ClInclude Include="..\..\..\signalrclient\transport_factory.h" />
     <ClInclude Include="..\..\..\signalrclient\url_builder.h" />
@@ -59,7 +58,6 @@
     <ClInclude Include="..\..\..\signalrclient\web_request.h" />
     <ClInclude Include="..\..\..\signalrclient\web_request_factory.h" />
     <ClInclude Include="..\..\..\signalrclient\web_response.h" />
-    <ClInclude Include="..\..\targetver.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\signalrclient\connection.cpp" />
@@ -79,6 +77,7 @@
     <ClCompile Include="..\..\..\signalrclient\transport.cpp" />
     <ClCompile Include="..\..\..\signalrclient\transport_factory.cpp" />
     <ClCompile Include="..\..\..\signalrclient\url_builder.cpp" />
+    <ClCompile Include="..\..\..\signalrclient\trace_log_writer.cpp" />
     <ClCompile Include="..\..\..\signalrclient\websocket_transport.cpp" />
     <ClCompile Include="..\..\..\signalrclient\web_request.cpp" />
     <ClCompile Include="..\..\..\signalrclient\web_request_factory.cpp" />

--- a/src/signalrclientdll/Build/VS2013/signalrclientdll.vcxproj.filters
+++ b/src/signalrclientdll/Build/VS2013/signalrclientdll.vcxproj.filters
@@ -15,9 +15,6 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\..\targetver.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\..\signalrclient\callback_manager.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -46,9 +43,6 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\signalrclient\request_sender.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\signalrclient\targetver.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\signalrclient\transport.h">
@@ -147,6 +141,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\signalrclient\url_builder.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\signalrclient\trace_log_writer.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\signalrclient\web_request.cpp">

--- a/src/signalrclientdll/targetver.h
+++ b/src/signalrclientdll/targetver.h
@@ -1,6 +1,0 @@
-// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
-
-#pragma once
-
-#include <SDKDDKVer.h>


### PR DESCRIPTION
- #ifdefing Windows specific stuff in stdafx.h
- Adding common 3rd party headers to stdafx.h to precompile them - makes build 25% faster
- Removing targetver.h - it was merged with stdafx.h