### PR TITLE
FollowUp

### DIFF
--- a/src/signalrclient/Build/VS2013/signalrclient.vcxproj
+++ b/src/signalrclient/Build/VS2013/signalrclient.vcxproj
@@ -24,7 +24,7 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <PreprocessorDefinitions>_WINDOWS;_USRDLL;NO_SIGNALRCLIENT_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\..\..\include;..\..\..\..\packages\cpprestsdk.2.2.0\build\native\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\..\include;..\..\..\..\packages\cpprestsdk.2.4.0.1\build\native\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/src/signalrclient/default_websocket_client.cpp
+++ b/src/signalrclient/default_websocket_client.cpp
@@ -8,9 +8,9 @@ namespace signalr
 {
     namespace
     {
-        static web_sockets::client::websocket_client_config create_client_config(const std::unordered_map<utility::string_t, utility::string_t>& headers)
+        static web::websockets::client::websocket_client_config create_client_config(const std::unordered_map<utility::string_t, utility::string_t>& headers)
         {
-            web_sockets::client::websocket_client_config config;
+            web::websockets::client::websocket_client_config config;
             for (auto &header : headers)
             {
                 config.headers()[header.first] = header.second;
@@ -31,7 +31,7 @@ namespace signalr
 
     pplx::task<void> default_websocket_client::send(const utility::string_t &message)
     {
-        web_sockets::client::websocket_outgoing_message msg;
+        web::websockets::client::websocket_outgoing_message msg;
         msg.set_utf8_message(utility::conversions::to_utf8string(message));
         return m_underlying_client.send(msg);
     }
@@ -40,7 +40,7 @@ namespace signalr
     {
         // the caller is responsible for observing exceptions
         return m_underlying_client.receive()
-            .then([](web_sockets::client::websocket_incoming_message msg)
+            .then([](web::websockets::client::websocket_incoming_message msg)
             {
                 return msg.extract_string();
             });

--- a/src/signalrclient/default_websocket_client.h
+++ b/src/signalrclient/default_websocket_client.h
@@ -7,8 +7,6 @@
 #include "cpprest\ws_client.h"
 #include "websocket_client.h"
 
-using namespace web::experimental;
-
 namespace signalr
 {
     class default_websocket_client : public websocket_client
@@ -25,6 +23,6 @@ namespace signalr
         pplx::task<void> close() override;
 
     private:
-        web_sockets::client::websocket_client m_underlying_client;
+        web::websockets::client::websocket_client m_underlying_client;
     };
 }

--- a/test/signalrclienttests/Build/VS2013/signalrclienttests.vcxproj
+++ b/test/signalrclienttests/Build/VS2013/signalrclienttests.vcxproj
@@ -20,7 +20,7 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <PreprocessorDefinitions>_CONSOLE;_LIB;NO_SIGNALRCLIENT_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\..\gtest-1.7.0\include;..\..\..\..\include;..\..\..\..\src\signalrclient;..\..\..\..\packages\cpprestsdk.2.2.0\build\native\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\gtest-1.7.0\include;..\..\..\..\include;..\..\..\..\src\signalrclient;..\..\..\..\packages\cpprestsdk.2.4.0.1\build\native\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/test/signalrclienttests/connection_impl_tests.cpp
+++ b/test/signalrclienttests/connection_impl_tests.cpp
@@ -13,7 +13,6 @@
 #include "cpprest\ws_client.h"
 
 using namespace signalr;
-using namespace web::experimental;
 
 static std::shared_ptr<connection_impl> create_connection(std::shared_ptr<websocket_client> websocket_client = create_test_websocket_client(),
     std::shared_ptr<log_writer> log_writer = std::make_shared<trace_log_writer>(), trace_level trace_level = trace_level::all)
@@ -58,7 +57,7 @@ TEST(connection_impl_start, connection_state_is_connecting_when_connection_is_be
         /* send function */ [](const utility::string_t){ return pplx::task_from_exception<void>(std::runtime_error("should not be invoked"));  },
         /* connect function */[](const web::uri&)
         {
-            return pplx::task_from_exception<void>(web_sockets::client::websocket_exception(_XPLATSTR("connecting failed")));
+            return pplx::task_from_exception<void>(web::websockets::client::websocket_exception(_XPLATSTR("connecting failed")));
         });
 
     auto connection = create_connection(websocket_client, writer, trace_level::errors);
@@ -167,7 +166,7 @@ TEST(connection_impl_start, start_fails_if_transport_connect_throws)
         /* send function */ [](const utility::string_t){ return pplx::task_from_exception<void>(std::runtime_error("should not be invoked"));  },
         /* connect function */[](const web::uri&)
         {
-            return pplx::task_from_exception<void>(web_sockets::client::websocket_exception(_XPLATSTR("connecting failed")));
+            return pplx::task_from_exception<void>(web::websockets::client::websocket_exception(_XPLATSTR("connecting failed")));
         });
 
     auto connection = create_connection(websocket_client, writer, trace_level::errors);

--- a/test/signalrclienttests/websocket_transport_tests.cpp
+++ b/test/signalrclienttests/websocket_transport_tests.cpp
@@ -9,7 +9,6 @@
 #include "memory_log_writer.h"
 
 using namespace signalr;
-using namespace web::experimental;
 
 TEST(websocket_transport_connect, connect_connects_and_starts_receive_loop)
 {
@@ -51,7 +50,7 @@ TEST(websocket_transport_connect, connect_propagates_exceptions)
     auto client = std::make_shared<test_websocket_client>();
     client->set_connect_function([](const web::uri &)->pplx::task<void>
     {
-        return pplx::task_from_exception<void>(web_sockets::client::websocket_exception(_XPLATSTR("connecting failed")));
+        return pplx::task_from_exception<void>(web::websockets::client::websocket_exception(_XPLATSTR("connecting failed")));
     });
 
     auto ws_transport = websocket_transport::create(client, logger(std::make_shared<trace_log_writer>(), trace_level::none),
@@ -73,7 +72,7 @@ TEST(websocket_transport_connect, connect_logs_exceptions)
     auto client = std::make_shared<test_websocket_client>();
     client->set_connect_function([](const web::uri &) -> pplx::task<void>
     {
-        return pplx::task_from_exception<void>(web_sockets::client::websocket_exception(_XPLATSTR("connecting failed")));
+        return pplx::task_from_exception<void>(web::websockets::client::websocket_exception(_XPLATSTR("connecting failed")));
     });
 
     std::shared_ptr<log_writer> writer(std::make_shared<memory_log_writer>());
@@ -225,7 +224,7 @@ TEST(websocket_transport_disconnect, disconnect_logs_exceptions)
     auto client = std::make_shared<test_websocket_client>();
     client->set_close_function([]()->pplx::task<void>
     {
-        return pplx::task_from_exception<void>(web_sockets::client::websocket_exception(_XPLATSTR("connection closing failed")));
+        return pplx::task_from_exception<void>(web::websockets::client::websocket_exception(_XPLATSTR("connection closing failed")));
     });
 
     std::shared_ptr<log_writer> writer(std::make_shared<memory_log_writer>());
@@ -342,7 +341,7 @@ void receive_loop_logs_exception_runner(const T& e, const utility::string_t& exp
 TEST(websocket_transport_receive_loop, receive_loop_logs_websocket_exceptions)
 {
     receive_loop_logs_exception_runner(
-        web_sockets::client::websocket_exception(_XPLATSTR("receive failed")),
+        web::websockets::client::websocket_exception(_XPLATSTR("receive failed")),
         _XPLATSTR("[error       ] [websocket transport] error receiving response from websocket: receive failed\n"),
         trace_level::errors);
 }


### PR DESCRIPTION
- fixing paths to includes (how did it even compile before, especially on the CI?)
- `websockets` namespace was pulled out from the `experimental` namespace and renamed from `web_sockets`