### PR TITLE
RaceyReconnects - fixing races when reconnecting

### DIFF
--- a/test/signalrclienttests/hub_connection_impl_tests.cpp
+++ b/test/signalrclienttests/hub_connection_impl_tests.cpp
@@ -159,8 +159,9 @@ TEST(start, start_sets_connection_data)
     {
     }
 
-    ASSERT_EQ(web::uri(create_uri().append(_XPLATSTR("/signalr/negotiate?clientProtocol=1.4&connectionData=%5B%7B%22Name%22:%22my_hub%22%7D,%7B%22Name%22:%22your_hub%22%7D%5D"))),
-        requested_url);
+    ASSERT_TRUE(
+        requested_url == web::uri(create_uri().append(_XPLATSTR("/signalr/negotiate?clientProtocol=1.4&connectionData=%5B%7B%22Name%22:%22my_hub%22%7D,%7B%22Name%22:%22your_hub%22%7D%5D"))) ||
+        requested_url == web::uri(create_uri().append(_XPLATSTR("/signalr/negotiate?clientProtocol=1.4&connectionData=%5B%7B%22Name%22:%22your_hub%22%7D,%7B%22Name%22:%22my_hub%22%7D%5D"))));
 }
 
 TEST(start, start_logs_if_no_hub_proxies_exist_for_hub_connection)

--- a/test/signalrclienttests/test_utils.cpp
+++ b/test/signalrclienttests/test_utils.cpp
@@ -58,3 +58,14 @@ utility::string_t create_uri()
     return utility::string_t(_XPLATSTR("http://"))
         .append(utility::conversions::to_string_t(unit_test->current_test_info()->name()));
 }
+
+
+std::vector<utility::string_t> filter_vector(const std::vector<utility::string_t>& source, const utility::string_t& string)
+{
+    std::vector<utility::string_t> filtered_entries;
+    std::copy_if(source.begin(), source.end(), std::back_inserter(filtered_entries), [&string](const utility::string_t &e)
+    {
+        return e.find(string) != utility::string_t::npos;
+    });
+    return filtered_entries;
+}

--- a/test/signalrclienttests/test_utils.cpp
+++ b/test/signalrclienttests/test_utils.cpp
@@ -59,7 +59,6 @@ utility::string_t create_uri()
         .append(utility::conversions::to_string_t(unit_test->current_test_info()->name()));
 }
 
-
 std::vector<utility::string_t> filter_vector(const std::vector<utility::string_t>& source, const utility::string_t& string)
 {
     std::vector<utility::string_t> filtered_entries;
@@ -68,4 +67,20 @@ std::vector<utility::string_t> filter_vector(const std::vector<utility::string_t
         return e.find(string) != utility::string_t::npos;
     });
     return filtered_entries;
+}
+
+utility::string_t dump_vector(const std::vector<utility::string_t>& source)
+{
+    utility::stringstream_t ss;
+    ss << _XPLATSTR("Number of entries: ") << source.size() << std::endl;
+    for (const auto& e : source)
+    {
+        ss << e;
+        if (e.back() != _XPLATSTR('\n'))
+        {
+            ss << std::endl;
+        }
+    }
+
+    return ss.str();
 }

--- a/test/signalrclienttests/test_utils.h
+++ b/test/signalrclienttests/test_utils.h
@@ -17,3 +17,4 @@ std::shared_ptr<signalr::websocket_client> create_test_websocket_client(
 
 std::unique_ptr<signalr::web_request_factory> create_test_web_request_factory();
 utility::string_t create_uri();
+std::vector<utility::string_t> filter_vector(const std::vector<utility::string_t>& source, const utility::string_t& string);

--- a/test/signalrclienttests/test_utils.h
+++ b/test/signalrclienttests/test_utils.h
@@ -18,3 +18,4 @@ std::shared_ptr<signalr::websocket_client> create_test_websocket_client(
 std::unique_ptr<signalr::web_request_factory> create_test_web_request_factory();
 utility::string_t create_uri();
 std::vector<utility::string_t> filter_vector(const std::vector<utility::string_t>& source, const utility::string_t& string);
+utility::string_t dump_vector(const std::vector<utility::string_t>& source);


### PR DESCRIPTION
Previously to prevent the user from deadlocking themselves in case the called `connection.stop()` from the `reconnecting` event we would first start the reconnecting process and then called the `reconnecting` event. This was racey since it was (very unlikely but still) possible that reconnect would finish quickly and would invoke `reconnected` callback before the `reconnecting` callback was invoked (happens once in a blue moon on a @BrennanConroy 's box). Another issue was that if the user called `connection.stop()` and `connection.start()` in the event the connection could be dropped so we would start a new reconnect attempt and as a result we would have 2 reconnecting attempts running in parallel but using the same disconnect cts and start event. The fix is to invoke the `reconnecting` event before starting the reconnecting process. We also copy the current disconnect cts which makes it possible to check if the connection was restarted in the `reconnecting` callback and if it was we are canceling this reconnect. This makes it impossible to have multiple concurrent reconnects.