### PR TITLE
add c++ end-to-end tests

### DIFF
--- a/signalrclient_VS2013.sln
+++ b/signalrclient_VS2013.sln
@@ -18,48 +18,114 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{063421
 		.nuget\NuGet.targets = .nuget\NuGet.targets
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{AABF08B1-12A4-4D06-A188-F01FBF8A9658}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "signalrclient-e2e-tests", "test\signalrclient-e2e-tests\Build\VS2013\signalrclient-e2e-tests.vcxproj", "{6006C96A-29F0-4B18-8DDD-764DC3419E2F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "signalrclient-testhost", "test\signalrclient-testhost\signalrclient-testhost.csproj", "{11848039-1F13-4047-9539-8F9F45930788}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|Mixed Platforms = Debug|Mixed Platforms
 		Debug|Win32 = Debug|Win32
 		Debug|x64 = Debug|x64
+		Release|Any CPU = Release|Any CPU
+		Release|Mixed Platforms = Release|Mixed Platforms
 		Release|Win32 = Release|Win32
 		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{87ED3AD4-D820-48CD-8382-A12564213A12}.Debug|Any CPU.ActiveCfg = Debug|Win32
+		{87ED3AD4-D820-48CD-8382-A12564213A12}.Debug|Mixed Platforms.ActiveCfg = Debug|Win32
+		{87ED3AD4-D820-48CD-8382-A12564213A12}.Debug|Mixed Platforms.Build.0 = Debug|Win32
 		{87ED3AD4-D820-48CD-8382-A12564213A12}.Debug|Win32.ActiveCfg = Debug|Win32
 		{87ED3AD4-D820-48CD-8382-A12564213A12}.Debug|Win32.Build.0 = Debug|Win32
 		{87ED3AD4-D820-48CD-8382-A12564213A12}.Debug|x64.ActiveCfg = Debug|x64
 		{87ED3AD4-D820-48CD-8382-A12564213A12}.Debug|x64.Build.0 = Debug|x64
+		{87ED3AD4-D820-48CD-8382-A12564213A12}.Release|Any CPU.ActiveCfg = Release|Win32
+		{87ED3AD4-D820-48CD-8382-A12564213A12}.Release|Mixed Platforms.ActiveCfg = Release|Win32
+		{87ED3AD4-D820-48CD-8382-A12564213A12}.Release|Mixed Platforms.Build.0 = Release|Win32
 		{87ED3AD4-D820-48CD-8382-A12564213A12}.Release|Win32.ActiveCfg = Release|Win32
 		{87ED3AD4-D820-48CD-8382-A12564213A12}.Release|Win32.Build.0 = Release|Win32
 		{87ED3AD4-D820-48CD-8382-A12564213A12}.Release|x64.ActiveCfg = Release|x64
 		{87ED3AD4-D820-48CD-8382-A12564213A12}.Release|x64.Build.0 = Release|x64
+		{10376148-BCF4-4B55-98A5-3C98C87FD898}.Debug|Any CPU.ActiveCfg = Debug|Win32
+		{10376148-BCF4-4B55-98A5-3C98C87FD898}.Debug|Mixed Platforms.ActiveCfg = Debug|Win32
+		{10376148-BCF4-4B55-98A5-3C98C87FD898}.Debug|Mixed Platforms.Build.0 = Debug|Win32
 		{10376148-BCF4-4B55-98A5-3C98C87FD898}.Debug|Win32.ActiveCfg = Debug|Win32
 		{10376148-BCF4-4B55-98A5-3C98C87FD898}.Debug|Win32.Build.0 = Debug|Win32
 		{10376148-BCF4-4B55-98A5-3C98C87FD898}.Debug|x64.ActiveCfg = Debug|x64
 		{10376148-BCF4-4B55-98A5-3C98C87FD898}.Debug|x64.Build.0 = Debug|x64
+		{10376148-BCF4-4B55-98A5-3C98C87FD898}.Release|Any CPU.ActiveCfg = Release|Win32
+		{10376148-BCF4-4B55-98A5-3C98C87FD898}.Release|Mixed Platforms.ActiveCfg = Release|Win32
+		{10376148-BCF4-4B55-98A5-3C98C87FD898}.Release|Mixed Platforms.Build.0 = Release|Win32
 		{10376148-BCF4-4B55-98A5-3C98C87FD898}.Release|Win32.ActiveCfg = Release|Win32
 		{10376148-BCF4-4B55-98A5-3C98C87FD898}.Release|Win32.Build.0 = Release|Win32
 		{10376148-BCF4-4B55-98A5-3C98C87FD898}.Release|x64.ActiveCfg = Release|x64
 		{10376148-BCF4-4B55-98A5-3C98C87FD898}.Release|x64.Build.0 = Release|x64
+		{2AF210A9-5BDC-45E8-95DD-07B5A2616493}.Debug|Any CPU.ActiveCfg = Debug|Win32
+		{2AF210A9-5BDC-45E8-95DD-07B5A2616493}.Debug|Mixed Platforms.ActiveCfg = Debug|Win32
+		{2AF210A9-5BDC-45E8-95DD-07B5A2616493}.Debug|Mixed Platforms.Build.0 = Debug|Win32
 		{2AF210A9-5BDC-45E8-95DD-07B5A2616493}.Debug|Win32.ActiveCfg = Debug|Win32
 		{2AF210A9-5BDC-45E8-95DD-07B5A2616493}.Debug|Win32.Build.0 = Debug|Win32
 		{2AF210A9-5BDC-45E8-95DD-07B5A2616493}.Debug|x64.ActiveCfg = Debug|x64
 		{2AF210A9-5BDC-45E8-95DD-07B5A2616493}.Debug|x64.Build.0 = Debug|x64
+		{2AF210A9-5BDC-45E8-95DD-07B5A2616493}.Release|Any CPU.ActiveCfg = Release|Win32
+		{2AF210A9-5BDC-45E8-95DD-07B5A2616493}.Release|Mixed Platforms.ActiveCfg = Release|Win32
+		{2AF210A9-5BDC-45E8-95DD-07B5A2616493}.Release|Mixed Platforms.Build.0 = Release|Win32
 		{2AF210A9-5BDC-45E8-95DD-07B5A2616493}.Release|Win32.ActiveCfg = Release|Win32
 		{2AF210A9-5BDC-45E8-95DD-07B5A2616493}.Release|Win32.Build.0 = Release|Win32
 		{2AF210A9-5BDC-45E8-95DD-07B5A2616493}.Release|x64.ActiveCfg = Release|x64
 		{2AF210A9-5BDC-45E8-95DD-07B5A2616493}.Release|x64.Build.0 = Release|x64
+		{18377AE8-E372-40CE-94FD-7F65008D39A3}.Debug|Any CPU.ActiveCfg = Debug|Win32
+		{18377AE8-E372-40CE-94FD-7F65008D39A3}.Debug|Mixed Platforms.ActiveCfg = Debug|Win32
+		{18377AE8-E372-40CE-94FD-7F65008D39A3}.Debug|Mixed Platforms.Build.0 = Debug|Win32
 		{18377AE8-E372-40CE-94FD-7F65008D39A3}.Debug|Win32.ActiveCfg = Debug|Win32
 		{18377AE8-E372-40CE-94FD-7F65008D39A3}.Debug|Win32.Build.0 = Debug|Win32
 		{18377AE8-E372-40CE-94FD-7F65008D39A3}.Debug|x64.ActiveCfg = Debug|x64
 		{18377AE8-E372-40CE-94FD-7F65008D39A3}.Debug|x64.Build.0 = Debug|x64
+		{18377AE8-E372-40CE-94FD-7F65008D39A3}.Release|Any CPU.ActiveCfg = Release|Win32
+		{18377AE8-E372-40CE-94FD-7F65008D39A3}.Release|Mixed Platforms.ActiveCfg = Release|Win32
+		{18377AE8-E372-40CE-94FD-7F65008D39A3}.Release|Mixed Platforms.Build.0 = Release|Win32
 		{18377AE8-E372-40CE-94FD-7F65008D39A3}.Release|Win32.ActiveCfg = Release|Win32
 		{18377AE8-E372-40CE-94FD-7F65008D39A3}.Release|Win32.Build.0 = Release|Win32
 		{18377AE8-E372-40CE-94FD-7F65008D39A3}.Release|x64.ActiveCfg = Release|x64
 		{18377AE8-E372-40CE-94FD-7F65008D39A3}.Release|x64.Build.0 = Release|x64
+		{6006C96A-29F0-4B18-8DDD-764DC3419E2F}.Debug|Any CPU.ActiveCfg = Debug|Win32
+		{6006C96A-29F0-4B18-8DDD-764DC3419E2F}.Debug|Mixed Platforms.ActiveCfg = Debug|Win32
+		{6006C96A-29F0-4B18-8DDD-764DC3419E2F}.Debug|Mixed Platforms.Build.0 = Debug|Win32
+		{6006C96A-29F0-4B18-8DDD-764DC3419E2F}.Debug|Win32.ActiveCfg = Debug|Win32
+		{6006C96A-29F0-4B18-8DDD-764DC3419E2F}.Debug|Win32.Build.0 = Debug|Win32
+		{6006C96A-29F0-4B18-8DDD-764DC3419E2F}.Debug|x64.ActiveCfg = Debug|x64
+		{6006C96A-29F0-4B18-8DDD-764DC3419E2F}.Debug|x64.Build.0 = Debug|x64
+		{6006C96A-29F0-4B18-8DDD-764DC3419E2F}.Release|Any CPU.ActiveCfg = Release|Win32
+		{6006C96A-29F0-4B18-8DDD-764DC3419E2F}.Release|Mixed Platforms.ActiveCfg = Release|Win32
+		{6006C96A-29F0-4B18-8DDD-764DC3419E2F}.Release|Mixed Platforms.Build.0 = Release|Win32
+		{6006C96A-29F0-4B18-8DDD-764DC3419E2F}.Release|Win32.ActiveCfg = Release|Win32
+		{6006C96A-29F0-4B18-8DDD-764DC3419E2F}.Release|Win32.Build.0 = Release|Win32
+		{6006C96A-29F0-4B18-8DDD-764DC3419E2F}.Release|x64.ActiveCfg = Release|x64
+		{6006C96A-29F0-4B18-8DDD-764DC3419E2F}.Release|x64.Build.0 = Release|x64
+		{11848039-1F13-4047-9539-8F9F45930788}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{11848039-1F13-4047-9539-8F9F45930788}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{11848039-1F13-4047-9539-8F9F45930788}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{11848039-1F13-4047-9539-8F9F45930788}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{11848039-1F13-4047-9539-8F9F45930788}.Debug|Win32.ActiveCfg = Debug|Any CPU
+		{11848039-1F13-4047-9539-8F9F45930788}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{11848039-1F13-4047-9539-8F9F45930788}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{11848039-1F13-4047-9539-8F9F45930788}.Release|Any CPU.Build.0 = Release|Any CPU
+		{11848039-1F13-4047-9539-8F9F45930788}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{11848039-1F13-4047-9539-8F9F45930788}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{11848039-1F13-4047-9539-8F9F45930788}.Release|Win32.ActiveCfg = Release|Any CPU
+		{11848039-1F13-4047-9539-8F9F45930788}.Release|x64.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{10376148-BCF4-4B55-98A5-3C98C87FD898} = {AABF08B1-12A4-4D06-A188-F01FBF8A9658}
+		{2AF210A9-5BDC-45E8-95DD-07B5A2616493} = {AABF08B1-12A4-4D06-A188-F01FBF8A9658}
+		{6006C96A-29F0-4B18-8DDD-764DC3419E2F} = {AABF08B1-12A4-4D06-A188-F01FBF8A9658}
+		{11848039-1F13-4047-9539-8F9F45930788} = {AABF08B1-12A4-4D06-A188-F01FBF8A9658}
 	EndGlobalSection
 EndGlobal

--- a/test/signalrclient-e2e-tests/Build/VS2013/packages.config
+++ b/test/signalrclient-e2e-tests/Build/VS2013/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="cpprestsdk" version="2.4.0.1" targetFramework="Native" />
+</packages>

--- a/test/signalrclient-e2e-tests/Build/VS2013/signalrclient-e2e-tests.vcxproj
+++ b/test/signalrclient-e2e-tests/Build/VS2013/signalrclient-e2e-tests.vcxproj
@@ -1,0 +1,72 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\..\..\packages\cpprestsdk.2.4.0.1\build\native\cpprestsdk.props" Condition="Exists('..\..\..\..\packages\cpprestsdk.2.4.0.1\build\native\cpprestsdk.props')" />
+  <Import Project="..\..\..\..\Build\SignalRClient.Build.Settings" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{6006C96A-29F0-4B18-8DDD-764DC3419E2F}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>signalrclient-e2e-tests</RootNamespace>
+    <ProjectName>signalrclient-e2e-tests</ProjectName>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\..\</SolutionDir>
+    <ConfigurationType>Application</ConfigurationType>
+  </PropertyGroup>
+  <Import Project="..\..\..\..\Build\Config.Definitions.props" />
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  <PropertyGroup Label="UserMacros">
+    <NuGetPackageImportStamp>f5caf114</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <PreprocessorDefinitions>_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\..\..\gtest-1.7.0\include;..\..\..\..\include\signalrclient;..\..\..\..\packages\cpprestsdk.2.4.0.1\build\native\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\test_utils.h" />
+    <ClInclude Include="..\..\stdafx.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\connection_tests.cpp" />
+    <ClCompile Include="..\..\hub_connection_tests.cpp" />
+    <ClCompile Include="..\..\test_utils.cpp" />
+    <ClCompile Include="..\..\signalrclient-e2e-tests.cpp" />
+    <ClCompile Include="..\..\stdafx.cpp">
+      <PrecompiledHeader>Create</PrecompiledHeader>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\signalrclientdll\Build\VS2013\signalrclientdll.vcxproj">
+      <Project>{18377ae8-e372-40ce-94fd-7f65008d39a3}</Project>
+      <CopyLocal>true</CopyLocal>
+      <CopyLocalSatelliteAssemblies>true</CopyLocalSatelliteAssemblies>
+      <LinkLibraryDependencies>true</LinkLibraryDependencies>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\gtest-1.7.0\msvc\gtest.vcxproj">
+      <Project>{2af210a9-5bdc-45e8-95dd-07b5a2616493}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+    <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+    <Import Project="..\..\..\..\packages\cpprestsdk.2.4.0.1\build\native\cpprestsdk.targets" Condition="Exists('..\..\..\..\packages\cpprestsdk.2.4.0.1\build\native\cpprestsdk.targets')" />
+  </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+    <Error Condition="!Exists('..\..\..\..\packages\cpprestsdk.2.4.0.1\build\native\cpprestsdk.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\cpprestsdk.2.4.0.1\build\native\cpprestsdk.props'))" />
+    <Error Condition="!Exists('..\..\..\..\packages\cpprestsdk.2.4.0.1\build\native\cpprestsdk.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\cpprestsdk.2.4.0.1\build\native\cpprestsdk.targets'))" />
+  </Target>
+  <Target Name="AfterBuild">
+    <Exec Command="copy /y &quot;$(SolutionDir)bin\$(Platform)\$(Configuration)\dll\signalrclient.dll&quot; &quot;$(SolutionDir)bin\$(Platform)\$(Configuration)\signalrclient.dll&quot;" />
+  </Target>
+</Project>

--- a/test/signalrclient-e2e-tests/Build/VS2013/signalrclient-e2e-tests.vcxproj.filters
+++ b/test/signalrclient-e2e-tests/Build/VS2013/signalrclient-e2e-tests.vcxproj.filters
@@ -1,0 +1,45 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\stdafx.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\test_utils.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\stdafx.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\signalrclient-e2e-tests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\connection_tests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\hub_connection_tests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\test_utils.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+</Project>

--- a/test/signalrclient-e2e-tests/connection_tests.cpp
+++ b/test/signalrclient-e2e-tests/connection_tests.cpp
@@ -1,0 +1,84 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#pragma once
+
+#include "stdafx.h"
+#include <string>
+#include "cpprest\details\basic_types.h"
+#include "cpprest\json.h" 
+#include "connection.h"
+#include "hub_connection.h"
+
+extern utility::string_t url;
+
+TEST(connection_tests, connection_status_start_stop)
+{
+    auto conn = std::make_shared<signalr::connection>(url + U("raw-connection"));
+
+    conn->start().get();
+    ASSERT_EQ(conn->get_connection_state(), signalr::connection_state::connected);
+
+    conn->stop().get();
+    ASSERT_EQ(conn->get_connection_state(), signalr::connection_state::disconnected);
+
+    conn->start().get();
+    ASSERT_EQ(conn->get_connection_state(), signalr::connection_state::connected);
+}
+
+TEST(connection_tests, send_message)
+{
+    auto conn = std::make_shared<signalr::connection>(url + U("raw-connection"));
+    auto message = std::make_shared<utility::string_t>();
+    auto received_event = std::make_shared<pplx::event>();
+
+    conn->set_message_received([message, received_event](const utility::string_t& payload)
+    {
+        *message = payload;
+        received_event->set();
+    });
+
+    conn->start().then([conn]()
+    {
+        web::json::value obj;
+        obj[U("type")] = web::json::value::number(0);
+        obj[U("value")] = web::json::value::string(U("test"));
+        return conn->send(obj.serialize());
+
+    }).get();
+
+    ASSERT_FALSE(received_event->wait(200));
+
+    ASSERT_EQ(*message, U("{\"data\":\"test\",\"type\":0}"));
+}
+
+TEST(connection_tests, send_message_after_connection_restart)
+{
+    auto conn = std::make_shared<signalr::connection>(url + U("raw-connection"));
+    auto message = std::make_shared<utility::string_t>();
+    auto received_event = std::make_shared<pplx::event>();
+
+    conn->set_message_received([message, received_event](const utility::string_t& payload)
+    {
+        *message = payload;
+        received_event->set();
+    });
+
+    conn->start().get();
+
+    conn->stop().get();
+
+    conn->start().then([conn]()
+    {
+        web::json::value obj;
+        obj[U("type")] = web::json::value::number(0);
+        obj[U("value")] = web::json::value::string(U("test"));
+        return conn->send(obj.serialize());
+
+    }).get();
+
+    ASSERT_FALSE(received_event->wait(200));
+
+    ASSERT_EQ(*message, U("{\"data\":\"test\",\"type\":0}"));
+}
+

--- a/test/signalrclient-e2e-tests/hub_connection_tests.cpp
+++ b/test/signalrclient-e2e-tests/hub_connection_tests.cpp
@@ -1,0 +1,184 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#pragma once
+
+#include "stdafx.h"
+#include <string>
+#include "cpprest\details\basic_types.h"
+#include "cpprest\json.h" 
+#include "connection.h"
+#include "hub_connection.h"
+
+extern utility::string_t url;
+
+TEST(hub_connection_tests, connection_status_start_stop_start_reconnect)
+{
+    auto hub_conn = std::make_shared<signalr::hub_connection>(url + U("SignalR"));
+    auto weak_hub_conn = std::weak_ptr<signalr::hub_connection>(hub_conn);
+    auto reconnecting_event = std::make_shared<pplx::event>();
+    auto reconnected_event = std::make_shared<pplx::event>();
+
+    auto hub_proxy = hub_conn->create_hub_proxy(U("hubConnection"));
+
+    hub_conn->set_reconnecting([weak_hub_conn, reconnecting_event]()
+    {
+        auto conn = weak_hub_conn.lock();
+        if (conn)
+        {
+            ASSERT_EQ(conn->get_connection_state(), signalr::connection_state::reconnecting);
+        }
+        reconnecting_event->set();
+    });
+
+    hub_conn->set_reconnected([weak_hub_conn, reconnected_event]()
+    {
+        auto conn = weak_hub_conn.lock();
+        if (conn)
+        {
+            ASSERT_EQ(conn->get_connection_state(), signalr::connection_state::connected);
+        }
+        reconnected_event->set();
+    });
+
+    hub_conn->start().get();
+    ASSERT_EQ(hub_conn->get_connection_state(), signalr::connection_state::connected);
+
+    hub_conn->stop().get();
+    ASSERT_EQ(hub_conn->get_connection_state(), signalr::connection_state::disconnected);
+
+    hub_conn->start().get();
+    ASSERT_EQ(hub_conn->get_connection_state(), signalr::connection_state::connected);
+
+    try
+    {
+        hub_proxy.invoke<web::json::value>(U("forceReconnect")).get();
+    }
+    catch (...)
+    {
+    }
+
+    ASSERT_FALSE(reconnecting_event->wait(200));
+
+    ASSERT_FALSE(reconnected_event->wait(100));
+}
+
+TEST(hub_connection_tests, send_message)
+{
+    auto hub_conn = std::make_shared<signalr::hub_connection>(url + U("SignalR"));
+    auto message = std::make_shared<utility::string_t>();
+    auto received_event = std::make_shared<pplx::event>();
+
+    auto hub_proxy = hub_conn->create_hub_proxy(U("hubConnection"));
+
+    hub_proxy.on(U("displayMessage"), [message, received_event](const web::json::value& arguments)
+    {
+        *message = arguments.serialize();
+        received_event->set();
+    });
+
+    hub_conn->start().then([&hub_proxy]()
+    {
+        web::json::value obj{};
+        obj[0] = web::json::value(U("test"));
+
+        return hub_proxy.invoke<web::json::value>(U("displayMessage"), obj);
+
+    }).get();
+
+    ASSERT_FALSE(received_event->wait(200));
+
+    ASSERT_EQ(*message, U("[\"Send: test\"]"));
+}
+
+TEST(hub_connection_tests, send_message_return)
+{
+    auto hub_conn = std::make_shared<signalr::hub_connection>(url + U("SignalR"));
+
+    auto hub_proxy = hub_conn->create_hub_proxy(U("hubConnection"));
+
+    auto test = hub_conn->start().then([&hub_proxy]()
+    {
+        web::json::value obj{};
+        obj[0] = web::json::value(U("test"));
+
+        return hub_proxy.invoke<web::json::value>(U("returnMessage"), obj);
+
+    }).get();
+
+    ASSERT_EQ(test.serialize(), U("\"test\""));
+}
+
+TEST(hub_connection_tests, send_message_after_connection_restart)
+{
+    auto hub_conn = std::make_shared<signalr::hub_connection>(url + U("SignalR"));
+    auto message = std::make_shared<utility::string_t>();
+    auto received_event = std::make_shared<pplx::event>();
+
+    auto hub_proxy = hub_conn->create_hub_proxy(U("hubConnection"));
+
+    hub_proxy.on(U("displayMessage"), [message, received_event](const web::json::value& arguments)
+    {
+        *message = arguments.serialize();
+        received_event->set();
+    });
+
+    hub_conn->start().get();
+
+    hub_conn->stop().get();
+
+    hub_conn->start().then([&hub_proxy]()
+    {
+        web::json::value obj{};
+        obj[0] = web::json::value(U("test"));
+
+        return hub_proxy.invoke<web::json::value>(U("displayMessage"), obj);
+
+    }).get();
+
+    ASSERT_FALSE(received_event->wait(200));
+
+    ASSERT_EQ(*message, U("[\"Send: test\"]"));
+}
+
+TEST(hub_connection_tests, send_message_after_reconnect)
+{
+    auto hub_conn = std::make_shared<signalr::hub_connection>(url + U("SignalR"));
+    auto message = std::make_shared<utility::string_t>();
+    auto reconnected_event = std::make_shared<pplx::event>();
+    auto received_event = std::make_shared<pplx::event>();
+
+    auto hub_proxy = hub_conn->create_hub_proxy(U("hubConnection"));
+
+    hub_conn->set_reconnected([reconnected_event]()
+    {
+        reconnected_event->set();
+    });
+
+    hub_proxy.on(U("displayMessage"), [message, received_event](const web::json::value& arguments)
+    {
+        *message = arguments.serialize();
+        received_event->set();
+    });
+
+    hub_conn->start().get();
+
+    try
+    {
+        hub_proxy.invoke<web::json::value>(U("forceReconnect")).get();
+    }
+    catch (...)
+    {
+    }
+
+    ASSERT_FALSE(reconnected_event->wait(300));
+
+    web::json::value obj{};
+    obj[0] = web::json::value(U("test"));
+
+    hub_proxy.invoke<web::json::value>(U("displayMessage"), obj).get();
+
+    ASSERT_FALSE(received_event->wait(200));
+
+    ASSERT_EQ(*message, U("[\"Send: test\"]"));
+}

--- a/test/signalrclient-e2e-tests/signalrclient-e2e-tests.cpp
+++ b/test/signalrclient-e2e-tests/signalrclient-e2e-tests.cpp
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#include "stdafx.h"
+#include <vector>
+#include "cpprest\details\basic_types.h"
+#include "test_utils.h"
+
+int wmain(int argc, utility::char_t* argv[])
+{
+    get_url(argc, argv);
+
+    ::testing::InitGoogleTest(&argc, argv);
+    RUN_ALL_TESTS();
+    return 0;
+}

--- a/test/signalrclient-e2e-tests/stdafx.cpp
+++ b/test/signalrclient-e2e-tests/stdafx.cpp
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#include "stdafx.h"

--- a/test/signalrclient-e2e-tests/stdafx.h
+++ b/test/signalrclient-e2e-tests/stdafx.h
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#pragma once
+
+#ifdef _WIN32
+// prevents from defining min/max macros that conflict with std::min()/std::max() functions
+#define NOMINMAX
+#endif
+
+#include "gtest\gtest.h"

--- a/test/signalrclient-e2e-tests/test_utils.cpp
+++ b/test/signalrclient-e2e-tests/test_utils.cpp
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#pragma once
+
+#include "stdafx.h"
+#include <string>
+#include "cpprest\details\basic_types.h"
+#include "cpprest\asyncrt_utils.h"
+#include <chrono>
+
+utility::string_t url;
+
+void get_url(int argc, utility::char_t* argv[])
+{
+    url = U("http://localhost:8081/");
+
+    for (int i = 0; i < argc; ++i)
+    {
+        utility::string_t str = argv[i];
+
+        auto pos = str.find(U("url="));
+        if (pos != std::string::npos)
+        {
+            url = str.substr(pos + 4);
+            break;
+        }
+    }
+}

--- a/test/signalrclient-e2e-tests/test_utils.h
+++ b/test/signalrclient-e2e-tests/test_utils.h
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#pragma once
+
+#include "stdafx.h"
+#include "cpprest\details\basic_types.h"
+
+void get_url(int argc, utility::char_t* argv[]);

--- a/test/signalrclient-testhost/App.config
+++ b/test/signalrclient-testhost/App.config
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+  </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.1.0" newVersion="3.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Owin.Security" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.1.0" newVersion="3.0.1.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/test/signalrclient-testhost/Connections/HubConnection.cs
+++ b/test/signalrclient-testhost/Connections/HubConnection.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNet.SignalR;
+
+namespace SelfHost
+{
+    public class HubConnection : Hub
+    {
+        public IEnumerable<int> ForceReconnect()
+        {
+            yield return 1;
+            // throwing here will close the websocket which should trigger reconnect
+            throw new Exception();
+        }
+
+        public void DisplayMessage(string message)
+        {
+            Clients.Caller.displayMessage("Send: " + message);
+        }
+
+        public string ReturnMessage(string message)
+        {
+            return message;
+        }
+    }
+}

--- a/test/signalrclient-testhost/Connections/RawConnection.cs
+++ b/test/signalrclient-testhost/Connections/RawConnection.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Threading;
+using Microsoft.AspNet.SignalR;
+using Newtonsoft.Json;
+
+namespace SelfHost
+{
+    public class RawConnection : PersistentConnection
+    {
+        protected override Task OnReceived(IRequest request, string connectionId, string data)
+        {
+            var message = JsonConvert.DeserializeObject<Message>(data);
+
+            switch (message.Type)
+            {
+                case MessageType.String:
+                    Connection.Send(connectionId, new { type = MessageType.String, data = message.Value });
+                    break;
+                default:
+                    break;
+            }
+
+            return base.OnReceived(request, connectionId, data);
+        }
+
+        enum MessageType
+        {
+            String
+        }
+
+        class Message
+        {
+            public MessageType Type { get; set; }
+            public string Value { get; set; }
+        }
+    }
+}

--- a/test/signalrclient-testhost/Program.cs
+++ b/test/signalrclient-testhost/Program.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Globalization;
+using System.Threading;
+using Microsoft.Owin.Hosting;
+
+namespace SelfHost
+{
+    public class Program
+    {
+        static void Main(string[] args)
+        {
+            using (WebApp.Start<Startup>("http://localhost:8081"))
+            {
+                Console.WriteLine("Server running at http://localhost:8081/");
+                Console.ReadLine();
+            }
+        }
+    }
+}

--- a/test/signalrclient-testhost/Properties/AssemblyInfo.cs
+++ b/test/signalrclient-testhost/Properties/AssemblyInfo.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("signalrclient-testhost")]
+[assembly: AssemblyCompany("Microsoft")]
+[assembly: AssemblyProduct("signalrclient-testhost")]
+[assembly: AssemblyCopyright("Copyright ©  2013")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("6b1e3377-fed7-45e6-a1a8-9787d2f9c8dd")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/test/signalrclient-testhost/Startup.cs
+++ b/test/signalrclient-testhost/Startup.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Globalization;
+using Owin;
+using Microsoft.AspNet.SignalR;
+
+namespace SelfHost
+{
+    public class Startup
+    {
+        public void Configuration(IAppBuilder app)
+        {
+            app.Map("/raw-connection", map =>
+            {
+                map.RunSignalR<RawConnection>();
+            });
+
+            app.Map("/signalr", map =>
+            {
+                map.RunSignalR();
+            });
+        }
+    }
+}

--- a/test/signalrclient-testhost/packages.config
+++ b/test/signalrclient-testhost/packages.config
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.AspNet.SignalR.Core" version="2.2.0" targetFramework="net451" />
+  <package id="Microsoft.AspNet.SignalR.SelfHost" version="2.2.0" targetFramework="net451" />
+  <package id="Microsoft.Owin" version="3.0.1" targetFramework="net451" />
+  <package id="Microsoft.Owin.Diagnostics" version="3.0.1" targetFramework="net451" />
+  <package id="Microsoft.Owin.Host.HttpListener" version="3.0.1" targetFramework="net451" />
+  <package id="Microsoft.Owin.Hosting" version="3.0.1" targetFramework="net451" />
+  <package id="Microsoft.Owin.Security" version="3.0.1" targetFramework="net451" />
+  <package id="Microsoft.Owin.SelfHost" version="3.0.1" targetFramework="net451" />
+  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net451" />
+  <package id="Owin" version="1.0" targetFramework="net451" />
+</packages>

--- a/test/signalrclient-testhost/signalrclient-testhost.csproj
+++ b/test/signalrclient-testhost/signalrclient-testhost.csproj
@@ -1,0 +1,103 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{11848039-1F13-4047-9539-8F9F45930788}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>SelfHost</RootNamespace>
+    <AssemblyName>signalrclient-testhost</AssemblyName>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <SccProjectName>SAK</SccProjectName>
+    <SccLocalPath>SAK</SccLocalPath>
+    <SccAuxPath>SAK</SccAuxPath>
+    <SccProvider>SAK</SccProvider>
+    <TargetFrameworkProfile />
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.AspNet.SignalR.Core">
+      <HintPath>..\..\packages\Microsoft.AspNet.SignalR.Core.2.2.0\lib\net45\Microsoft.AspNet.SignalR.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Owin">
+      <HintPath>..\..\packages\Microsoft.Owin.3.0.1\lib\net45\Microsoft.Owin.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Diagnostics">
+      <HintPath>..\..\packages\Microsoft.Owin.Diagnostics.3.0.1\lib\net45\Microsoft.Owin.Diagnostics.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Host.HttpListener">
+      <HintPath>..\..\packages\Microsoft.Owin.Host.HttpListener.3.0.1\lib\net45\Microsoft.Owin.Host.HttpListener.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Hosting">
+      <HintPath>..\..\packages\Microsoft.Owin.Hosting.3.0.1\lib\net45\Microsoft.Owin.Hosting.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Security">
+      <HintPath>..\..\packages\Microsoft.Owin.Security.3.0.1\lib\net45\Microsoft.Owin.Security.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="Owin">
+      <HintPath>..\..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Connections\HubConnection.cs" />
+    <Compile Include="Connections\RawConnection.cs" />
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Startup.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+  </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>


### PR DESCRIPTION
Added e2e tests for below scenarios: 
send message, send message after connection re-start, send message after reconnect 

Support ulr can be specified in commandline parameter as well, like:
signalrclient-e2e-tests.exe url=http://server1:8081/

I will have separate PR for hub method parameter tests etc.

Now the host is moved to test, not in sample.