### PR TITLE
GhostsFromThePastLife - fixing a bug where stray errors caused reconnect...

### DIFF
--- a/test/signalrclient-e2e-tests/connection_tests.cpp
+++ b/test/signalrclient-e2e-tests/connection_tests.cpp
@@ -6,7 +6,7 @@
 #include "stdafx.h"
 #include <string>
 #include "cpprest\details\basic_types.h"
-#include "cpprest\json.h" 
+#include "cpprest\json.h"
 #include "connection.h"
 #include "hub_connection.h"
 
@@ -47,7 +47,7 @@ TEST(connection_tests, send_message)
 
     }).get();
 
-    ASSERT_FALSE(received_event->wait(200));
+    ASSERT_FALSE(received_event->wait(2000));
 
     ASSERT_EQ(*message, U("{\"data\":\"test\",\"type\":0}"));
 }
@@ -77,7 +77,7 @@ TEST(connection_tests, send_message_after_connection_restart)
 
     }).get();
 
-    ASSERT_FALSE(received_event->wait(200));
+    ASSERT_FALSE(received_event->wait(2000));
 
     ASSERT_EQ(*message, U("{\"data\":\"test\",\"type\":0}"));
 }

--- a/test/signalrclient-e2e-tests/hub_connection_tests.cpp
+++ b/test/signalrclient-e2e-tests/hub_connection_tests.cpp
@@ -6,7 +6,7 @@
 #include "stdafx.h"
 #include <string>
 #include "cpprest\details\basic_types.h"
-#include "cpprest\json.h" 
+#include "cpprest\json.h"
 #include "connection.h"
 #include "hub_connection.h"
 
@@ -58,9 +58,8 @@ TEST(hub_connection_tests, connection_status_start_stop_start_reconnect)
     {
     }
 
-    ASSERT_FALSE(reconnecting_event->wait(200));
-
-    ASSERT_FALSE(reconnected_event->wait(100));
+    ASSERT_FALSE(reconnecting_event->wait(2000));
+    ASSERT_FALSE(reconnected_event->wait(2000));
 }
 
 TEST(hub_connection_tests, send_message)
@@ -136,7 +135,7 @@ TEST(hub_connection_tests, send_message_after_connection_restart)
 
     }).get();
 
-    ASSERT_FALSE(received_event->wait(200));
+    ASSERT_FALSE(received_event->wait(2000));
 
     ASSERT_EQ(*message, U("[\"Send: test\"]"));
 }
@@ -171,14 +170,14 @@ TEST(hub_connection_tests, send_message_after_reconnect)
     {
     }
 
-    ASSERT_FALSE(reconnected_event->wait(300));
+    ASSERT_FALSE(reconnected_event->wait(2000));
 
     web::json::value obj{};
     obj[0] = web::json::value(U("test"));
 
     hub_proxy.invoke<web::json::value>(U("displayMessage"), obj).get();
 
-    ASSERT_FALSE(received_event->wait(200));
+    ASSERT_FALSE(received_event->wait(2000));
 
     ASSERT_EQ(*message, U("[\"Send: test\"]"));
 }

--- a/test/signalrclient-testhost/Program.cs
+++ b/test/signalrclient-testhost/Program.cs
@@ -1,10 +1,8 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Globalization;
-using System.Threading;
 using Microsoft.Owin.Hosting;
+using System;
 
 namespace SelfHost
 {

--- a/test/signalrclient-testhost/Startup.cs
+++ b/test/signalrclient-testhost/Startup.cs
@@ -1,9 +1,7 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Globalization;
 using Owin;
-using Microsoft.AspNet.SignalR;
 
 namespace SelfHost
 {


### PR DESCRIPTION
...s

When we stop a connection we just signal that the transport should be stopped but don't wait for it to actually stop. If then the same connection is immediately started the old transport can still be running. Because the callbacks are not reset when stopping the transport errors and messages from the old transport can still invoke them on the newly started connection. This is especially harmful in case of errors because they would cause reconnects. The fix is to ignore any message or error received from a transport started by a connection that has already been stopped.