### PR TITLE
Replace web::json with signalr::value on public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ PS> .\submodules\vcpkg\bootstrap-vcpkg.bat
 PS> .\submodules\vcpkg\vcpkg.exe install cpprestsdk:x64-windows
 PS> mkdir build.release
 PS> cd build.release
-PS> cmake .. -A x64 -DCMAKE_TOOLCHAIN_FILE="..\submodules\vcpkg\scripts\buildsystems\vcpkg.cmake" -DCMAKE_BUILD_TYPE=Release
+PS> cmake .. -A x64 -DCMAKE_TOOLCHAIN_FILE="..\submodules\vcpkg\scripts\buildsystems\vcpkg.cmake" -DCMAKE_BUILD_TYPE=Release -DUSE_CPPRESTSDK=true
 PS> cmake --build . --config Release
 ```
 Output will be in `build.release\bin\Release\`
@@ -24,7 +24,7 @@ $ ./submodules/vcpkg/bootstrap-vcpkg.sh
 $ ./submodules/vcpkg/vcpkg install cpprestsdk
 $ mkdir build.release
 $ cd build.release
-$ cmake .. -DCMAKE_TOOLCHAIN_FILE=../submodules/vcpkg/scripts/buildsystems/vcpkg.cmake -DCMAKE_BUILD_TYPE=Release
+$ cmake .. -DCMAKE_TOOLCHAIN_FILE=../submodules/vcpkg/scripts/buildsystems/vcpkg.cmake -DCMAKE_BUILD_TYPE=Release -DUSE_CPPRESTSDK=true
 $ cmake --build . --config Release
 ```
 Output will be in `build.release/bin/`
@@ -37,7 +37,7 @@ $ ./submodules/vcpkg/bootstrap-vcpkg.sh
 $ ./submodules/vcpkg/vcpkg install cpprestsdk boost-system boost-chrono boost-thread
 $ mkdir build.release
 $ cd build.release
-$ cmake .. -DCMAKE_TOOLCHAIN_FILE=../submodules/vcpkg/scripts/buildsystems/vcpkg.cmake -DCMAKE_BUILD_TYPE=Release
+$ cmake .. -DCMAKE_TOOLCHAIN_FILE=../submodules/vcpkg/scripts/buildsystems/vcpkg.cmake -DCMAKE_BUILD_TYPE=Release -DUSE_CPPRESTSDK=true
 $ cmake --build . --config Release
 ```
 Output will be in `build.release/bin/`

--- a/include/signalrclient/hub_connection.h
+++ b/include/signalrclient/hub_connection.h
@@ -19,7 +19,7 @@ namespace signalr
     class hub_connection
     {
     public:
-        typedef std::function<void __cdecl (const web::json::value&)> method_invoked_handler;
+        typedef std::function<void __cdecl (const signalr::value&)> method_invoked_handler;
 
         SIGNALRCLIENT_API explicit hub_connection(const std::string& url, trace_level trace_level = trace_level::all,
             std::shared_ptr<log_writer> log_writer = nullptr);

--- a/include/signalrclient/hub_connection.h
+++ b/include/signalrclient/hub_connection.h
@@ -6,11 +6,11 @@
 #include "_exports.h"
 #include <memory>
 #include <functional>
-#include "cpprest/json.h"
 #include "connection_state.h"
 #include "trace_level.h"
 #include "log_writer.h"
 #include "signalr_client_config.h"
+#include "signalr_value.h"
 
 namespace signalr
 {
@@ -42,9 +42,9 @@ namespace signalr
 
         SIGNALRCLIENT_API void __cdecl on(const std::string& event_name, const method_invoked_handler& handler);
 
-        SIGNALRCLIENT_API void invoke(const std::string& method_name, const web::json::value& arguments = web::json::value::array(), std::function<void(const web::json::value&, std::exception_ptr)> callback = [](const web::json::value&, std::exception_ptr) {}) noexcept;
+        SIGNALRCLIENT_API void invoke(const std::string& method_name, const signalr::value& arguments = signalr::value(), std::function<void(const signalr::value&, std::exception_ptr)> callback = [](const signalr::value&, std::exception_ptr) {}) noexcept;
 
-        SIGNALRCLIENT_API void send(const std::string& method_name, const web::json::value& arguments = web::json::value::array(), std::function<void(std::exception_ptr)> callback = [](std::exception_ptr) {}) noexcept;
+        SIGNALRCLIENT_API void send(const std::string& method_name, const signalr::value& arguments = signalr::value(), std::function<void(std::exception_ptr)> callback = [](std::exception_ptr) {}) noexcept;
 
     private:
         std::shared_ptr<hub_connection_impl> m_pImpl;

--- a/include/signalrclient/signalr_value.h
+++ b/include/signalrclient/signalr_value.h
@@ -28,323 +28,156 @@ namespace signalr
     class value
     {
     public:
-        value() : mType(value_type::null) {}
+        /**
+         * Create an object representing a value_type::null value.
+         */
+        value();
 
-        value(value_type t) : mType(t)
-        {
-            switch (mType)
-            {
-            case value_type::array:
-                new (&mStorage.arr) std::vector<value>();
-                break;
-            case value_type::string:
-                new (&mStorage.str) std::string();
-                break;
-            case value_type::float64:
-                mStorage.number = 0;
-                break;
-            case value_type::boolean:
-                mStorage.boolean = false;
-                break;
-            case value_type::map:
-                new (&mStorage.map) std::map<std::string, value>();
-                break;
-            }
-        }
+        /**
+         * Create an object representing a default value for the given value_type.
+         */
+        value(value_type t);
 
-        value(bool val) : mType(value_type::boolean)
-        {
-            mStorage.boolean = val;
-        }
+        /**
+         * Create an object representing a value_type::boolean with the given bool value.
+         */
+        value(bool val);
 
-        value(int val) : mType(value_type::float64)
-        {
-            mStorage.number = val;
-        }
+        /**
+         * Create an object representing a value_type::float64 with the given double value.
+         */
+        value(double val);
 
-        value(double val) : mType(value_type::float64)
-        {
-            mStorage.number = val;
-        }
+        /**
+         * Create an object representing a value_type::string with the given string value.
+         */
+        value(const std::string& val);
 
-        value(const std::string& val) : mType(value_type::string)
-        {
-            new (&mStorage.str) std::string(val);
-        }
+        /**
+         * Create an object representing a value_type::string with the given string value.
+         */
+        value(std::string&& val);
 
-        value(std::string&& val) : mType(value_type::string)
-        {
-            new (&mStorage.str) std::string(std::move(val));
-        }
+        /**
+         * Create an object representing a value_type::array with the given vector of value's.
+         */
+        value(const std::vector<value>& val);
 
-        value(const std::vector<value>& val) : mType(value_type::array)
-        {
-            new (&mStorage.arr) std::vector<value>(val);
-        }
+        /**
+         * Create an object representing a value_type::array with the given vector of value's.
+         */
+        value(std::vector<value>&& val);
 
-        value(std::vector<value>&& val) : mType(value_type::array)
-        {
-            new (&mStorage.arr) std::vector<value>(std::move(val));
-        }
+        /**
+         * Create an object representing a value_type::map with the given map of string-value's.
+         */
+        value(const std::map<std::string, value>& map);
 
-        value(const std::map<std::string, value>& map) : mType(value_type::map)
-        {
-            new (&mStorage.map) std::map<std::string, value>(map);
-        }
+        /**
+         * Create an object representing a value_type::map with the given map of string-value's.
+         */
+        value(std::map<std::string, value>&& map);
 
-        value(std::map<std::string, value>&& map) : mType(value_type::map)
-        {
-            new (&mStorage.map) std::map<std::string, value>(std::move(map));
-        }
+        /**
+         * Copies an existing value.
+         */
+        value(const value& rhs);
 
-        value(const value& rhs)
-        {
-            mType = rhs.mType;
-            switch (mType)
-            {
-            case value_type::array:
-                new (&mStorage.arr) std::vector<value>(rhs.mStorage.arr);
-                break;
-            case value_type::string:
-                new (&mStorage.str) std::string(rhs.mStorage.str);
-                break;
-            case value_type::float64:
-                mStorage.number = rhs.mStorage.number;
-                break;
-            case value_type::boolean:
-                mStorage.boolean = rhs.mStorage.boolean;
-                break;
-            case value_type::map:
-                new (&mStorage.map) std::map<std::string, value>(rhs.mStorage.map);
-                break;
-            }
-        }
+        /**
+         * Moves an existing value.
+         */
+        value(value&& rhs) noexcept;
 
-        value(value&& rhs)
-        {
-            mType = std::move(rhs.mType);
-            switch (mType)
-            {
-            case value_type::array:
-                new (&mStorage.arr) std::vector<signalr::value>(std::move(rhs.mStorage.arr));
-                break;
-            case value_type::string:
-                new (&mStorage.str) std::string(std::move(rhs.mStorage.str));
-                break;
-            case value_type::float64:
-                mStorage.number = std::move(rhs.mStorage.number);
-                break;
-            case value_type::boolean:
-                mStorage.boolean = std::move(rhs.mStorage.boolean);
-                break;
-            case value_type::map:
-                new (&mStorage.map) std::map<std::string, signalr::value>(std::move(rhs.mStorage.map));
-                break;
-            }
-        }
+        /**
+         * Cleans up the resources associated with the value.
+         */
+        ~value();
 
-        ~value()
-        {
-            switch (mType)
-            {
-            case value_type::array:
-                mStorage.arr.~vector();
-                break;
-            case value_type::string:
-                mStorage.str.~basic_string();
-                break;
-            case value_type::map:
-                mStorage.map.~map();
-                break;
-            }
-        }
+        /**
+         * Copies an existing value.
+         */
+        value& operator=(const value& rhs);
 
-        value& operator=(const value& rhs)
-        {
-            mType = rhs.mType;
-            switch (mType)
-            {
-            case value_type::array:
-                new (&mStorage.arr) std::vector<value>(rhs.mStorage.arr);
-                break;
-            case value_type::string:
-                new (&mStorage.str) std::string(rhs.mStorage.str);
-                break;
-            case value_type::float64:
-                mStorage.number = rhs.mStorage.number;
-                break;
-            case value_type::boolean:
-                mStorage.boolean = rhs.mStorage.boolean;
-                break;
-            case value_type::map:
-                new (&mStorage.map) std::map<std::string, value>(rhs.mStorage.map);
-                break;
-            }
-
-            return *this;
-        }
-
-        value& operator=(value&& rhs)
-        {
-            mType = std::move(rhs.mType);
-            switch (mType)
-            {
-            case value_type::array:
-                new (&mStorage.arr) std::vector<value>(std::move(rhs.mStorage.arr));
-                break;
-            case value_type::string:
-                new (&mStorage.str) std::string(std::move(rhs.mStorage.str));
-                break;
-            case value_type::float64:
-                mStorage.number = std::move(rhs.mStorage.number);
-                break;
-            case value_type::boolean:
-                mStorage.boolean = std::move(rhs.mStorage.boolean);
-                break;
-            case value_type::map:
-                new (&mStorage.map) std::map<std::string, value>(std::move(rhs.mStorage.map));
-                break;
-            }
-
-            return *this;
-        }
+        /**
+         * Moves an existing value.
+         */
+        value& operator=(value&& rhs) noexcept;
 
         /**
          * True if the object stored is a Key-Value pair.
          */
-        bool is_map() const
-        {
-            return mType == signalr::value_type::map;
-        }
+        bool is_map() const;
 
         /**
          * True if the object stored is a double.
          */
-        bool is_double() const
-        {
-            return mType == signalr::value_type::float64;
-        }
+        bool is_double() const;
 
         /**
          * True if the object stored is a string.
          */
-        bool is_string() const
-        {
-            return mType == signalr::value_type::string;
-        }
+        bool is_string() const;
 
         /**
          * True if the object stored is empty.
          */
-        bool is_null() const
-        {
-            return mType == signalr::value_type::null;
-        }
+        bool is_null() const;
 
         /**
          * True if the object stored is an array of signalr::value's.
          */
-        bool is_array() const
-        {
-            return mType == signalr::value_type::array;
-        }
+        bool is_array() const;
 
         /**
          * True if the object stored is a bool.
          */
-        bool is_bool() const
-        {
-            return mType == signalr::value_type::boolean;
-        }
+        bool is_bool() const;
 
         /**
          * Returns the stored object as a double. This will throw if the underlying object is not a signalr::type::float64.
          */
-        double as_double() const
-        {
-            if (!is_double())
-            {
-                throw std::exception();
-            }
-
-            return mStorage.number;
-        }
+        double as_double() const;
 
         /**
          * Returns the stored object as a bool. This will throw if the underlying object is not a signalr::type::boolean.
          */
-        bool as_bool() const
-        {
-            if (!is_bool())
-            {
-                throw std::exception();
-            }
-
-            return mStorage.boolean;
-        }
+        bool as_bool() const;
 
         /**
          * Returns the stored object as a string. This will throw if the underlying object is not a signalr::type::string.
          */
-        const std::string& as_string() const
-        {
-            if (!is_string())
-            {
-                throw std::exception();
-            }
-
-            return mStorage.str;
-        }
+        const std::string& as_string() const;
 
         /**
          * Returns the stored object as an array of signalr::value's. This will throw if the underlying object is not a signalr::type::array.
          */
-        std::vector<value> as_array() const
-        {
-            if (!is_array())
-            {
-                throw std::exception();
-            }
-
-            return mStorage.arr;
-        }
+        const std::vector<value>& as_array() const;
 
         /**
          * Returns the stored object as a map of property name to signalr::value. This will throw if the underlying object is not a signalr::type::map.
          */
-        std::map<std::string, value> as_map() const
-        {
-            if (!is_map())
-            {
-                throw std::exception();
-            }
-
-            return mStorage.map;
-        }
+        const std::map<std::string, value>& as_map() const;
 
         /**
          * Returns the signalr::type that represents the stored object.
          */
-        value_type type() const
-        {
-            return mType;
-        }
+        value_type type() const;
 
     private:
         value_type mType;
 
-        union S
+        union storage
         {
             bool boolean;
-            std::string str;
-            std::vector<value> arr;
+            std::string string;
+            std::vector<value> array;
             double number;
             std::map<std::string, value> map;
 
-            S() {}
-            ~S() {}
+            storage() {}
+            ~storage() {}
         };
 
-        S mStorage;
+        storage mStorage;
     };
 }

--- a/include/signalrclient/signalr_value.h
+++ b/include/signalrclient/signalr_value.h
@@ -38,32 +38,50 @@ namespace signalr
         /**
          * True if the object stored is a Key-Value pair.
          */
-        bool is_map() const;
+        bool is_map() const
+        {
+            return mType == signalr::type::MAP;
+        }
 
         /**
          * True if the object stored is double.
          */
-        bool is_double() const;
+        bool is_double() const
+        {
+            return mType == signalr::type::DOUBLE;
+        }
 
         /**
          * True if the object stored is a string.
          */
-        bool is_string() const;
+        bool is_string() const
+        {
+            return mType == signalr::type::STRING;
+        }
 
         /**
          * True if the object stored is empty.
          */
-        bool is_null() const;
+        bool is_null() const
+        {
+            return mType == signalr::type::NULL;
+        }
 
         /**
          * True if the object stored is an array of signalr::value's.
          */
-        bool is_array() const;
+        bool is_array() const
+        {
+            return mType == signalr::type::ARRAY;
+        }
 
         /**
          * True if the object stored is a bool.
          */
-        bool is_bool() const;
+        bool is_bool() const
+        {
+            return mType == signalr::type::BOOL;
+        }
 
         /**
          * Returns the stored object as a double. This will throw if the underlying object is not a signalr::type::float64.
@@ -73,26 +91,88 @@ namespace signalr
         /**
          * Returns the stored object as a bool. This will throw if the underlying object is not a signalr::type::boolean.
          */
-        bool as_bool() const;
+        bool as_bool() const
+        {
+            if (!is_bool())
+            {
+                throw std::exception();
+            }
+
+            return false;
+        }
+
+        /**
+         * Returns the stored object as a double. The value will be cast to a double if the underlying object is a signalr::type::NUMBER otherwise it will throw
+         */
+        double as_double() const
+        {
+            if (!is_double())
+            {
+                throw std::exception();
+            }
+
+            return 1.0;
+        }
 
         /**
          * Returns the stored object as a string. This will throw if the underlying object is not a signalr::type::string.
          */
-        const std::string& as_string() const;
+        const std::string& as_string() const
+        {
+            if (!is_string())
+            {
+                throw std::exception();
+            }
+
+            return "";
+        }
 
         /**
          * Returns the stored object as an array of signalr::value's. This will throw if the underlying object is not a signalr::type::array.
          */
-        std::vector<value> as_array() const;
+        std::vector<value> as_array() const
+        {
+            if (!is_array())
+            {
+                throw std::exception();
+            }
+
+            return std::vector<value>();
+        }
 
         /**
          * Returns the stored object as a map of property name to signalr::value. This will throw if the underlying object is not a signalr::type::map.
          */
-        std::map<std::string, value> as_map() const;
+        std::map<std::string, value> as_map() const
+        {
+            if (!is_map())
+            {
+                throw std::exception();
+            }
+
+            return std::map<std::string, value>();
+        }
 
         /**
          * Returns the signalr::type that represents the stored object.
          */
-        type type() const;
+        type type() const
+        {
+            return mType;
+        }
+
+    private:
+        signalr::type mType;
+
+        union storage
+        {
+            bool boolean;
+            std::string str;
+            std::vector<value> arr;
+            double number;
+            std::map<std::string, value> map;
+        };
+
+        storage mStorage;
     };
 }

--- a/include/signalrclient/signalr_value.h
+++ b/include/signalrclient/signalr_value.h
@@ -169,6 +169,31 @@ namespace signalr
             return *this;
         }
 
+        value& operator=(value&& rhs)
+        {
+            mType = std::move(rhs.mType);
+            switch (mType)
+            {
+            case type::array:
+                new (&mStorage.arr) std::vector<value>(std::move(rhs.mStorage.arr));
+                break;
+            case type::string:
+                new (&mStorage.str) std::string(std::move(rhs.mStorage.str));
+                break;
+            case type::float64:
+                mStorage.number = std::move(rhs.mStorage.number);
+                break;
+            case type::boolean:
+                mStorage.boolean = std::move(rhs.mStorage.boolean);
+                break;
+            case type::map:
+                new (&mStorage.map) std::map<std::string, value>(std::move(rhs.mStorage.map));
+                break;
+            }
+
+            return *this;
+        }
+
         /**
          * True if the object stored is a Key-Value pair.
          */

--- a/include/signalrclient/signalr_value.h
+++ b/include/signalrclient/signalr_value.h
@@ -72,14 +72,29 @@ namespace signalr
             new (&mStorage.str) std::string(val);
         }
 
+        value(std::string&& val) : mType(type::string)
+        {
+            new (&mStorage.str) std::string(std::move(val));
+        }
+
         value(const std::vector<value>& val) : mType(type::array)
         {
             new (&mStorage.arr) std::vector<value>(val);
         }
 
+        value(std::vector<value>&& val) : mType(type::array)
+        {
+            new (&mStorage.arr) std::vector<value>(std::move(val));
+        }
+
         value(const std::map<std::string, value>& map) : mType(type::map)
         {
             new (&mStorage.map) std::map<std::string, value>(map);
+        }
+
+        value(std::map<std::string, value>&& map) : mType(type::map)
+        {
+            new (&mStorage.map) std::map<std::string, value>(std::move(map));
         }
 
         value(const value& rhs)

--- a/include/signalrclient/signalr_value.h
+++ b/include/signalrclient/signalr_value.h
@@ -12,7 +12,7 @@ namespace signalr
     /**
      * An enum defining the types a signalr::value may be.
      */
-    enum class type
+    enum class value_type
     {
         map,
         array,
@@ -28,71 +28,71 @@ namespace signalr
     class value
     {
     public:
-        value() : mType(type::null) {}
+        value() : mType(value_type::null) {}
 
-        value(type t) : mType(t)
+        value(value_type t) : mType(t)
         {
             switch (mType)
             {
-            case type::array:
+            case value_type::array:
                 new (&mStorage.arr) std::vector<value>();
                 break;
-            case type::string:
+            case value_type::string:
                 new (&mStorage.str) std::string();
                 break;
-            case type::float64:
+            case value_type::float64:
                 mStorage.number = 0;
                 break;
-            case type::boolean:
+            case value_type::boolean:
                 mStorage.boolean = false;
                 break;
-            case type::map:
+            case value_type::map:
                 new (&mStorage.map) std::map<std::string, value>();
                 break;
             }
         }
 
-        value(bool val) : mType(type::boolean)
+        value(bool val) : mType(value_type::boolean)
         {
             mStorage.boolean = val;
         }
 
-        value(int val) : mType(type::float64)
+        value(int val) : mType(value_type::float64)
         {
             mStorage.number = val;
         }
 
-        value(double val) : mType(type::float64)
+        value(double val) : mType(value_type::float64)
         {
             mStorage.number = val;
         }
 
-        value(const std::string& val) : mType(type::string)
+        value(const std::string& val) : mType(value_type::string)
         {
             new (&mStorage.str) std::string(val);
         }
 
-        value(std::string&& val) : mType(type::string)
+        value(std::string&& val) : mType(value_type::string)
         {
             new (&mStorage.str) std::string(std::move(val));
         }
 
-        value(const std::vector<value>& val) : mType(type::array)
+        value(const std::vector<value>& val) : mType(value_type::array)
         {
             new (&mStorage.arr) std::vector<value>(val);
         }
 
-        value(std::vector<value>&& val) : mType(type::array)
+        value(std::vector<value>&& val) : mType(value_type::array)
         {
             new (&mStorage.arr) std::vector<value>(std::move(val));
         }
 
-        value(const std::map<std::string, value>& map) : mType(type::map)
+        value(const std::map<std::string, value>& map) : mType(value_type::map)
         {
             new (&mStorage.map) std::map<std::string, value>(map);
         }
 
-        value(std::map<std::string, value>&& map) : mType(type::map)
+        value(std::map<std::string, value>&& map) : mType(value_type::map)
         {
             new (&mStorage.map) std::map<std::string, value>(std::move(map));
         }
@@ -102,19 +102,19 @@ namespace signalr
             mType = rhs.mType;
             switch (mType)
             {
-            case type::array:
+            case value_type::array:
                 new (&mStorage.arr) std::vector<value>(rhs.mStorage.arr);
                 break;
-            case type::string:
+            case value_type::string:
                 new (&mStorage.str) std::string(rhs.mStorage.str);
                 break;
-            case type::float64:
+            case value_type::float64:
                 mStorage.number = rhs.mStorage.number;
                 break;
-            case type::boolean:
+            case value_type::boolean:
                 mStorage.boolean = rhs.mStorage.boolean;
                 break;
-            case type::map:
+            case value_type::map:
                 new (&mStorage.map) std::map<std::string, value>(rhs.mStorage.map);
                 break;
             }
@@ -125,19 +125,19 @@ namespace signalr
             mType = std::move(rhs.mType);
             switch (mType)
             {
-            case type::array:
+            case value_type::array:
                 new (&mStorage.arr) std::vector<signalr::value>(std::move(rhs.mStorage.arr));
                 break;
-            case type::string:
+            case value_type::string:
                 new (&mStorage.str) std::string(std::move(rhs.mStorage.str));
                 break;
-            case type::float64:
+            case value_type::float64:
                 mStorage.number = std::move(rhs.mStorage.number);
                 break;
-            case type::boolean:
+            case value_type::boolean:
                 mStorage.boolean = std::move(rhs.mStorage.boolean);
                 break;
-            case type::map:
+            case value_type::map:
                 new (&mStorage.map) std::map<std::string, signalr::value>(std::move(rhs.mStorage.map));
                 break;
             }
@@ -147,13 +147,13 @@ namespace signalr
         {
             switch (mType)
             {
-            case type::array:
+            case value_type::array:
                 mStorage.arr.~vector();
                 break;
-            case type::string:
+            case value_type::string:
                 mStorage.str.~basic_string();
                 break;
-            case type::map:
+            case value_type::map:
                 mStorage.map.~map();
                 break;
             }
@@ -164,19 +164,19 @@ namespace signalr
             mType = rhs.mType;
             switch (mType)
             {
-            case type::array:
+            case value_type::array:
                 new (&mStorage.arr) std::vector<value>(rhs.mStorage.arr);
                 break;
-            case type::string:
+            case value_type::string:
                 new (&mStorage.str) std::string(rhs.mStorage.str);
                 break;
-            case type::float64:
+            case value_type::float64:
                 mStorage.number = rhs.mStorage.number;
                 break;
-            case type::boolean:
+            case value_type::boolean:
                 mStorage.boolean = rhs.mStorage.boolean;
                 break;
-            case type::map:
+            case value_type::map:
                 new (&mStorage.map) std::map<std::string, value>(rhs.mStorage.map);
                 break;
             }
@@ -189,19 +189,19 @@ namespace signalr
             mType = std::move(rhs.mType);
             switch (mType)
             {
-            case type::array:
+            case value_type::array:
                 new (&mStorage.arr) std::vector<value>(std::move(rhs.mStorage.arr));
                 break;
-            case type::string:
+            case value_type::string:
                 new (&mStorage.str) std::string(std::move(rhs.mStorage.str));
                 break;
-            case type::float64:
+            case value_type::float64:
                 mStorage.number = std::move(rhs.mStorage.number);
                 break;
-            case type::boolean:
+            case value_type::boolean:
                 mStorage.boolean = std::move(rhs.mStorage.boolean);
                 break;
-            case type::map:
+            case value_type::map:
                 new (&mStorage.map) std::map<std::string, value>(std::move(rhs.mStorage.map));
                 break;
             }
@@ -214,7 +214,7 @@ namespace signalr
          */
         bool is_map() const
         {
-            return mType == signalr::type::map;
+            return mType == signalr::value_type::map;
         }
 
         /**
@@ -222,7 +222,7 @@ namespace signalr
          */
         bool is_double() const
         {
-            return mType == signalr::type::float64;
+            return mType == signalr::value_type::float64;
         }
 
         /**
@@ -230,7 +230,7 @@ namespace signalr
          */
         bool is_string() const
         {
-            return mType == signalr::type::string;
+            return mType == signalr::value_type::string;
         }
 
         /**
@@ -238,7 +238,7 @@ namespace signalr
          */
         bool is_null() const
         {
-            return mType == signalr::type::null;
+            return mType == signalr::value_type::null;
         }
 
         /**
@@ -246,7 +246,7 @@ namespace signalr
          */
         bool is_array() const
         {
-            return mType == signalr::type::array;
+            return mType == signalr::value_type::array;
         }
 
         /**
@@ -254,7 +254,7 @@ namespace signalr
          */
         bool is_bool() const
         {
-            return mType == signalr::type::boolean;
+            return mType == signalr::value_type::boolean;
         }
 
         /**
@@ -325,13 +325,13 @@ namespace signalr
         /**
          * Returns the signalr::type that represents the stored object.
          */
-        type type() const
+        value_type type() const
         {
             return mType;
         }
 
     private:
-        signalr::type mType;
+        value_type mType;
 
         union S
         {

--- a/samples/HubConnectionSample/CMakeLists.txt
+++ b/samples/HubConnectionSample/CMakeLists.txt
@@ -1,10 +1,10 @@
-set (SOURCES 
+set (SOURCES
   HubConnectionSample.cpp
 )
 
 include_directories(
     ../../include/signalrclient)
- 
+
 add_executable (HubConnectionSample ${SOURCES})
 
 target_link_libraries(HubConnectionSample signalrclient)

--- a/src/signalrclient/CMakeLists.txt
+++ b/src/signalrclient/CMakeLists.txt
@@ -9,6 +9,7 @@ set (SOURCES
   logger.cpp
   negotiate.cpp
   signalr_client_config.cpp
+  signalr_value.cpp
   stdafx.cpp
   trace_log_writer.cpp
   transport.cpp

--- a/src/signalrclient/callback_manager.cpp
+++ b/src/signalrclient/callback_manager.cpp
@@ -3,12 +3,13 @@
 
 #include "stdafx.h"
 #include "callback_manager.h"
+#include <sstream>
 
 namespace signalr
 {
     // dtor_clear_arguments will be passed when closing any pending callbacks when the `callback_manager` is
     // destroyed (i.e. in the dtor)
-    callback_manager::callback_manager(const web::json::value& dtor_clear_arguments)
+    callback_manager::callback_manager(const signalr::value& dtor_clear_arguments)
         : m_dtor_clear_arguments(dtor_clear_arguments)
     { }
 
@@ -18,7 +19,7 @@ namespace signalr
     }
 
     // note: callback must not throw except for the `on_progress` callback which will never be invoked from the dtor
-    std::string callback_manager::register_callback(const std::function<void(const web::json::value&)>& callback)
+    std::string callback_manager::register_callback(const std::function<void(const signalr::value&)>& callback)
     {
         auto callback_id = get_callback_id();
 
@@ -33,9 +34,9 @@ namespace signalr
 
 
     // invokes a callback and stops tracking it if remove callback set to true
-    bool callback_manager::invoke_callback(const std::string& callback_id, const web::json::value& arguments, bool remove_callback)
+    bool callback_manager::invoke_callback(const std::string& callback_id, const signalr::value& arguments, bool remove_callback)
     {
-        std::function<void(const web::json::value& arguments)> callback;
+        std::function<void(const signalr::value& arguments)> callback;
 
         {
             std::lock_guard<std::mutex> lock(m_map_lock);
@@ -67,7 +68,7 @@ namespace signalr
         }
     }
 
-    void callback_manager::clear(const web::json::value& arguments)
+    void callback_manager::clear(const signalr::value& arguments)
     {
         {
             std::lock_guard<std::mutex> lock(m_map_lock);

--- a/src/signalrclient/callback_manager.h
+++ b/src/signalrclient/callback_manager.h
@@ -7,29 +7,29 @@
 #include <unordered_map>
 #include <functional>
 #include <mutex>
-#include "cpprest/json.h"
+#include "signalrclient/signalr_value.h"
 
 namespace signalr
 {
     class callback_manager
     {
     public:
-        explicit callback_manager(const web::json::value& dtor_error);
+        explicit callback_manager(const signalr::value& dtor_error);
         ~callback_manager();
 
         callback_manager(const callback_manager&) = delete;
         callback_manager& operator=(const callback_manager&) = delete;
 
-        std::string register_callback(const std::function<void(const web::json::value&)>& callback);
-        bool invoke_callback(const std::string& callback_id, const web::json::value& arguments, bool remove_callback);
+        std::string register_callback(const std::function<void(const signalr::value&)>& callback);
+        bool invoke_callback(const std::string& callback_id, const signalr::value& arguments, bool remove_callback);
         bool remove_callback(const std::string& callback_id);
-        void clear(const web::json::value& arguments);
+        void clear(const signalr::value& arguments);
 
     private:
         std::atomic<int> m_id { 0 };
-        std::unordered_map<std::string, std::function<void(const web::json::value&)>> m_callbacks;
+        std::unordered_map<std::string, std::function<void(const signalr::value&)>> m_callbacks;
         std::mutex m_map_lock;
-        const web::json::value m_dtor_clear_arguments;
+        const signalr::value m_dtor_clear_arguments;
 
         std::string get_callback_id();
     };

--- a/src/signalrclient/hub_connection.cpp
+++ b/src/signalrclient/hub_connection.cpp
@@ -47,18 +47,18 @@ namespace signalr
         return m_pImpl->on(event_name, handler);
     }
 
-    void hub_connection::invoke(const std::string& method_name, const web::json::value& arguments, std::function<void(const web::json::value&, std::exception_ptr)> callback) noexcept
+    void hub_connection::invoke(const std::string& method_name, const signalr::value& arguments, std::function<void(const signalr::value&, std::exception_ptr)> callback) noexcept
     {
         if (!m_pImpl)
         {
-            callback(web::json::value(), std::make_exception_ptr(signalr_exception("invoke() cannot be called on destructed hub_connection instance")));
+            callback(signalr::value(), std::make_exception_ptr(signalr_exception("invoke() cannot be called on destructed hub_connection instance")));
             return;
         }
 
         return m_pImpl->invoke(method_name, arguments, callback);
     }
 
-    void hub_connection::send(const std::string& method_name, const web::json::value& arguments, std::function<void(std::exception_ptr)> callback) noexcept
+    void hub_connection::send(const std::string& method_name, const signalr::value& arguments, std::function<void(std::exception_ptr)> callback) noexcept
     {
         if (!m_pImpl)
         {

--- a/src/signalrclient/hub_connection_impl.cpp
+++ b/src/signalrclient/hub_connection_impl.cpp
@@ -461,7 +461,7 @@ namespace signalr
             {
                 assert(message.is_map());
                 const auto& map = message.as_map();
-                auto& found = map.find("result");
+                auto found = map.find("result");
                 if (found != map.end())
                 {
                     set_result(found->second);

--- a/src/signalrclient/hub_connection_impl.cpp
+++ b/src/signalrclient/hub_connection_impl.cpp
@@ -366,13 +366,13 @@ namespace signalr
     {
         if (!message.is_map())
         {
-            throw std::exception("expected object");
+            throw signalr_exception("expected object");
         }
 
-        auto invocationId = message.as_map()["invocationId"];
+        auto invocationId = message.as_map().at("invocationId");
         if (!invocationId.is_string())
         {
-            throw std::exception("invocationId is not a string");
+            throw signalr_exception("invocationId is not a string");
         }
 
         auto id = invocationId.as_string();
@@ -389,7 +389,7 @@ namespace signalr
     {
         if (!arguments.is_array())
         {
-            callback(signalr::value(), std::make_exception_ptr(std::exception("arguments should be an array")));
+            callback(signalr::value(), std::make_exception_ptr(signalr_exception("arguments should be an array")));
             return;
         }
 
@@ -405,7 +405,7 @@ namespace signalr
     {
         if (!arguments.is_array())
         {
-            callback(std::make_exception_ptr(std::exception("arguments should be an array")));
+            callback(std::make_exception_ptr(signalr_exception("arguments should be an array")));
             return;
         }
 

--- a/src/signalrclient/hub_connection_impl.cpp
+++ b/src/signalrclient/hub_connection_impl.cpp
@@ -230,15 +230,15 @@ namespace signalr
     {
         switch (v.type())
         {
-        case signalr::type::boolean:
+        case signalr::value_type::boolean:
             return web::json::value(v.as_bool());
-        case signalr::type::float64:
+        case signalr::value_type::float64:
             return web::json::value(v.as_double());
-        case signalr::type::string:
+        case signalr::value_type::string:
             return web::json::value(utility::conversions::to_string_t(v.as_string()));
-        case signalr::type::array:
+        case signalr::value_type::array:
         {
-            auto& array = v.as_array();
+            const auto& array = v.as_array();
             auto vec = std::vector<web::json::value>();
             for (auto& val : array)
             {
@@ -246,9 +246,9 @@ namespace signalr
             }
             return web::json::value::array(vec);
         }
-        case signalr::type::map:
+        case signalr::value_type::map:
         {
-            auto& obj = v.as_map();
+            const auto& obj = v.as_map();
             auto o = web::json::value::object();
             for (auto& val : obj)
             {
@@ -256,7 +256,7 @@ namespace signalr
             }
             return o;
         }
-        case signalr::type::null:
+        case signalr::value_type::null:
         default:
             return web::json::value::null();
         }
@@ -460,7 +460,7 @@ namespace signalr
             return [logger, set_result, set_exception](const signalr::value& message)
             {
                 assert(message.is_map());
-                auto& map = message.as_map();
+                const auto& map = message.as_map();
                 auto& found = map.find("result");
                 if (found != map.end())
                 {

--- a/src/signalrclient/hub_connection_impl.cpp
+++ b/src/signalrclient/hub_connection_impl.cpp
@@ -190,7 +190,7 @@ namespace signalr
         Close,
     };
 
-    signalr::value createValue(const web::json::value v)
+    signalr::value createValue(const web::json::value& v)
     {
         switch (v.type())
         {
@@ -208,7 +208,7 @@ namespace signalr
             {
                 vec.push_back(createValue(val));
             }
-            return signalr::value(vec);
+            return signalr::value(std::move(vec));
         }
         case web::json::value::Object:
         {
@@ -218,7 +218,7 @@ namespace signalr
             {
                 map.insert({ utility::conversions::to_utf8string(val.first), createValue(val.second) });
             }
-            return signalr::value(map);
+            return signalr::value(std::move(map));
         }
         case web::json::value::Null:
         default:
@@ -226,7 +226,7 @@ namespace signalr
         }
     }
 
-    web::json::value createJson(const signalr::value v)
+    web::json::value createJson(const signalr::value& v)
     {
         switch (v.type())
         {

--- a/src/signalrclient/hub_connection_impl.h
+++ b/src/signalrclient/hub_connection_impl.h
@@ -8,6 +8,7 @@
 #include "callback_manager.h"
 #include "case_insensitive_comparison_utils.h"
 #include "completion_event.h"
+#include "signalrclient/signalr_value.h"
 
 using namespace web;
 
@@ -31,10 +32,10 @@ namespace signalr
         hub_connection_impl(const hub_connection_impl&) = delete;
         hub_connection_impl& operator=(const hub_connection_impl&) = delete;
 
-        void on(const std::string& event_name, const std::function<void(const json::value &)>& handler);
+        void on(const std::string& event_name, const std::function<void(const signalr::value &)>& handler);
 
-        void invoke(const std::string& method_name, const json::value& arguments, std::function<void(const json::value&, std::exception_ptr)> callback) noexcept;
-        void send(const std::string& method_name, const json::value& arguments, std::function<void(std::exception_ptr)> callback) noexcept;
+        void invoke(const std::string& method_name, const signalr::value& arguments, std::function<void(const signalr::value&, std::exception_ptr)> callback) noexcept;
+        void send(const std::string& method_name, const signalr::value& arguments, std::function<void(std::exception_ptr)> callback) noexcept;
 
         void start(std::function<void(std::exception_ptr)> callback) noexcept;
         void stop(std::function<void(std::exception_ptr)> callback) noexcept;
@@ -52,7 +53,7 @@ namespace signalr
         std::shared_ptr<connection_impl> m_connection;
         logger m_logger;
         callback_manager m_callback_manager;
-        std::unordered_map<std::string, std::function<void(const json::value &)>, case_insensitive_hash, case_insensitive_equals> m_subscriptions;
+        std::unordered_map<std::string, std::function<void(const signalr::value&)>, case_insensitive_hash, case_insensitive_equals> m_subscriptions;
         bool m_handshakeReceived;
         std::shared_ptr<completion_event> m_handshakeTask;
         std::function<void()> m_disconnected;
@@ -62,8 +63,8 @@ namespace signalr
 
         void process_message(const std::string& message);
 
-        void invoke_hub_method(const std::string& method_name, const json::value& arguments, const std::string& callback_id,
+        void invoke_hub_method(const std::string& method_name, const signalr::value& arguments, const std::string& callback_id,
             std::function<void()> set_completion, std::function<void(const std::exception_ptr)> set_exception) noexcept;
-        bool invoke_callback(const web::json::value& message);
+        bool invoke_callback(const signalr::value& message);
     };
 }

--- a/src/signalrclient/hub_connection_impl.h
+++ b/src/signalrclient/hub_connection_impl.h
@@ -10,8 +10,6 @@
 #include "completion_event.h"
 #include "signalrclient/signalr_value.h"
 
-using namespace web;
-
 namespace signalr
 {
     // Note:

--- a/src/signalrclient/signalr_value.cpp
+++ b/src/signalrclient/signalr_value.cpp
@@ -1,0 +1,9 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#include "stdafx.h"
+#include "signalrclient/signalr_value.h"
+
+namespace signalr
+{
+}

--- a/src/signalrclient/signalr_value.cpp
+++ b/src/signalrclient/signalr_value.cpp
@@ -6,4 +6,264 @@
 
 namespace signalr
 {
+    value::value() : mType(value_type::null) {}
+
+    value::value(value_type t) : mType(t)
+    {
+        switch (mType)
+        {
+        case value_type::array:
+            new (&mStorage.array) std::vector<value>();
+            break;
+        case value_type::string:
+            new (&mStorage.string) std::string();
+            break;
+        case value_type::float64:
+            mStorage.number = 0;
+            break;
+        case value_type::boolean:
+            mStorage.boolean = false;
+            break;
+        case value_type::map:
+            new (&mStorage.map) std::map<std::string, value>();
+            break;
+        }
+    }
+
+    value::value(bool val) : mType(value_type::boolean)
+    {
+        mStorage.boolean = val;
+    }
+
+    value::value(double val) : mType(value_type::float64)
+    {
+        mStorage.number = val;
+    }
+
+    value::value(const std::string& val) : mType(value_type::string)
+    {
+        new (&mStorage.string) std::string(val);
+    }
+
+    value::value(std::string&& val) : mType(value_type::string)
+    {
+        new (&mStorage.string) std::string(std::move(val));
+    }
+
+    value::value(const std::vector<value>& val) : mType(value_type::array)
+    {
+        new (&mStorage.array) std::vector<value>(val);
+    }
+
+    value::value(std::vector<value>&& val) : mType(value_type::array)
+    {
+        new (&mStorage.array) std::vector<value>(std::move(val));
+    }
+
+    value::value(const std::map<std::string, value>& map) : mType(value_type::map)
+    {
+        new (&mStorage.map) std::map<std::string, value>(map);
+    }
+
+    value::value(std::map<std::string, value>&& map) : mType(value_type::map)
+    {
+        new (&mStorage.map) std::map<std::string, value>(std::move(map));
+    }
+
+    value::value(const value& rhs)
+    {
+        mType = rhs.mType;
+        switch (mType)
+        {
+        case value_type::array:
+            new (&mStorage.array) std::vector<value>(rhs.mStorage.array);
+            break;
+        case value_type::string:
+            new (&mStorage.string) std::string(rhs.mStorage.string);
+            break;
+        case value_type::float64:
+            mStorage.number = rhs.mStorage.number;
+            break;
+        case value_type::boolean:
+            mStorage.boolean = rhs.mStorage.boolean;
+            break;
+        case value_type::map:
+            new (&mStorage.map) std::map<std::string, value>(rhs.mStorage.map);
+            break;
+        }
+    }
+
+    value::value(value&& rhs) noexcept
+    {
+        mType = std::move(rhs.mType);
+        switch (mType)
+        {
+        case value_type::array:
+            new (&mStorage.array) std::vector<signalr::value>(std::move(rhs.mStorage.array));
+            break;
+        case value_type::string:
+            new (&mStorage.string) std::string(std::move(rhs.mStorage.string));
+            break;
+        case value_type::float64:
+            mStorage.number = std::move(rhs.mStorage.number);
+            break;
+        case value_type::boolean:
+            mStorage.boolean = std::move(rhs.mStorage.boolean);
+            break;
+        case value_type::map:
+            new (&mStorage.map) std::map<std::string, signalr::value>(std::move(rhs.mStorage.map));
+            break;
+        }
+    }
+
+    value::~value()
+    {
+        switch (mType)
+        {
+        case value_type::array:
+            mStorage.array.~vector();
+            break;
+        case value_type::string:
+            mStorage.string.~basic_string();
+            break;
+        case value_type::map:
+            mStorage.map.~map();
+            break;
+        }
+    }
+
+    value& value::operator=(const value& rhs)
+    {
+        mType = rhs.mType;
+        switch (mType)
+        {
+        case value_type::array:
+            new (&mStorage.array) std::vector<value>(rhs.mStorage.array);
+            break;
+        case value_type::string:
+            new (&mStorage.string) std::string(rhs.mStorage.string);
+            break;
+        case value_type::float64:
+            mStorage.number = rhs.mStorage.number;
+            break;
+        case value_type::boolean:
+            mStorage.boolean = rhs.mStorage.boolean;
+            break;
+        case value_type::map:
+            new (&mStorage.map) std::map<std::string, value>(rhs.mStorage.map);
+            break;
+        }
+
+        return *this;
+    }
+
+    value& value::operator=(value&& rhs) noexcept
+    {
+        mType = std::move(rhs.mType);
+        switch (mType)
+        {
+        case value_type::array:
+            new (&mStorage.array) std::vector<value>(std::move(rhs.mStorage.array));
+            break;
+        case value_type::string:
+            new (&mStorage.string) std::string(std::move(rhs.mStorage.string));
+            break;
+        case value_type::float64:
+            mStorage.number = std::move(rhs.mStorage.number);
+            break;
+        case value_type::boolean:
+            mStorage.boolean = std::move(rhs.mStorage.boolean);
+            break;
+        case value_type::map:
+            new (&mStorage.map) std::map<std::string, value>(std::move(rhs.mStorage.map));
+            break;
+        }
+
+        return *this;
+    }
+
+    bool value::is_map() const
+    {
+        return mType == signalr::value_type::map;
+    }
+
+    bool value::is_double() const
+    {
+        return mType == signalr::value_type::float64;
+    }
+
+    bool value::is_string() const
+    {
+        return mType == signalr::value_type::string;
+    }
+
+    bool value::is_null() const
+    {
+        return mType == signalr::value_type::null;
+    }
+
+    bool value::is_array() const
+    {
+        return mType == signalr::value_type::array;
+    }
+
+    bool value::is_bool() const
+    {
+        return mType == signalr::value_type::boolean;
+    }
+
+    double value::as_double() const
+    {
+        if (!is_double())
+        {
+            throw std::exception();
+        }
+
+        return mStorage.number;
+    }
+
+    bool value::as_bool() const
+    {
+        if (!is_bool())
+        {
+            throw std::exception();
+        }
+
+        return mStorage.boolean;
+    }
+
+    const std::string& value::as_string() const
+    {
+        if (!is_string())
+        {
+            throw std::exception();
+        }
+
+        return mStorage.string;
+    }
+
+    const std::vector<value>& value::as_array() const
+    {
+        if (!is_array())
+        {
+            throw std::exception();
+        }
+
+        return mStorage.array;
+    }
+
+    const std::map<std::string, value>& value::as_map() const
+    {
+        if (!is_map())
+        {
+            throw std::exception();
+        }
+
+        return mStorage.map;
+    }
+
+    value_type value::type() const
+    {
+        return mType;
+    }
 }

--- a/src/signalrclient/signalr_value.cpp
+++ b/src/signalrclient/signalr_value.cpp
@@ -3,9 +3,32 @@
 
 #include "stdafx.h"
 #include "signalrclient/signalr_value.h"
+#include "signalrclient/signalr_exception.h"
+#include <string>
 
 namespace signalr
 {
+    std::string value_type_to_string(value_type v)
+    {
+        switch (v)
+        {
+        case signalr::value_type::map:
+            return "map";
+        case signalr::value_type::array:
+            return "array";
+        case signalr::value_type::string:
+            return "string";
+        case signalr::value_type::float64:
+            return "float64";
+        case signalr::value_type::null:
+            return "null";
+        case signalr::value_type::boolean:
+            return "boolean";
+        default:
+            return std::to_string((int)v);
+        }
+    }
+
     value::value() : mType(value_type::null) {}
 
     value::value(value_type t) : mType(t)
@@ -228,7 +251,7 @@ namespace signalr
     {
         if (!is_double())
         {
-            throw std::exception();
+            throw signalr_exception("object is a '" + value_type_to_string(mType) + "' expected it to be a 'float64'");
         }
 
         return mStorage.number;
@@ -238,7 +261,7 @@ namespace signalr
     {
         if (!is_bool())
         {
-            throw std::exception();
+            throw signalr_exception("object is a '" + value_type_to_string(mType) + "' expected it to be a 'boolean'");
         }
 
         return mStorage.boolean;
@@ -248,7 +271,7 @@ namespace signalr
     {
         if (!is_string())
         {
-            throw std::exception();
+            throw signalr_exception("object is a '" + value_type_to_string(mType) + "' expected it to be a 'string'");
         }
 
         return mStorage.string;
@@ -258,7 +281,7 @@ namespace signalr
     {
         if (!is_array())
         {
-            throw std::exception();
+            throw signalr_exception("object is a '" + value_type_to_string(mType) + "' expected it to be a 'array'");
         }
 
         return mStorage.array;
@@ -268,7 +291,7 @@ namespace signalr
     {
         if (!is_map())
         {
-            throw std::exception();
+            throw signalr_exception("object is a '" + value_type_to_string(mType) + "' expected it to be a 'map'");
         }
 
         return mStorage.map;

--- a/src/signalrclient/signalr_value.cpp
+++ b/src/signalrclient/signalr_value.cpp
@@ -27,6 +27,8 @@ namespace signalr
         case value_type::map:
             new (&mStorage.map) std::map<std::string, value>();
             break;
+        default:
+            break;
         }
     }
 
@@ -90,6 +92,8 @@ namespace signalr
         case value_type::map:
             new (&mStorage.map) std::map<std::string, value>(rhs.mStorage.map);
             break;
+        default:
+            break;
         }
     }
 
@@ -113,6 +117,8 @@ namespace signalr
         case value_type::map:
             new (&mStorage.map) std::map<std::string, signalr::value>(std::move(rhs.mStorage.map));
             break;
+        default:
+            break;
         }
     }
 
@@ -128,6 +134,8 @@ namespace signalr
             break;
         case value_type::map:
             mStorage.map.~map();
+            break;
+        default:
             break;
         }
     }
@@ -151,6 +159,8 @@ namespace signalr
             break;
         case value_type::map:
             new (&mStorage.map) std::map<std::string, value>(rhs.mStorage.map);
+            break;
+        default:
             break;
         }
 
@@ -176,6 +186,8 @@ namespace signalr
             break;
         case value_type::map:
             new (&mStorage.map) std::map<std::string, value>(std::move(rhs.mStorage.map));
+            break;
+        default:
             break;
         }
 

--- a/test/signalrclienttests/callback_manager_tests.cpp
+++ b/test/signalrclienttests/callback_manager_tests.cpp
@@ -5,59 +5,58 @@
 #include "callback_manager.h"
 
 using namespace signalr;
-using namespace web;
 
 TEST(callback_manager_register_callback, register_returns_unique_callback_ids)
 {
-    callback_manager callback_mgr{ json::value::object() };
-    auto callback_id1 = callback_mgr.register_callback([](const json::value&){});
-    auto callback_id2 = callback_mgr.register_callback([](const web::json::value&){});
+    callback_manager callback_mgr{ signalr::value() };
+    auto callback_id1 = callback_mgr.register_callback([](const signalr::value&){});
+    auto callback_id2 = callback_mgr.register_callback([](const signalr::value&){});
 
     ASSERT_NE(callback_id1, callback_id2);
 }
 
 TEST(callback_manager_invoke_callback, invoke_callback_invokes_and_removes_callback_if_remove_callback_true)
 {
-    callback_manager callback_mgr{ json::value::object() };
+    callback_manager callback_mgr{ signalr::value() };
 
-    std::string callback_argument{ "" };
+    int callback_argument;
 
     auto callback_id = callback_mgr.register_callback(
-        [&callback_argument](const json::value& argument)
+        [&callback_argument](const signalr::value& argument)
         {
-            callback_argument = utility::conversions::to_utf8string(argument.serialize());
+            callback_argument = argument.as_double();
         });
 
-    auto callback_found = callback_mgr.invoke_callback(callback_id, json::value::number(42), true);
+    auto callback_found = callback_mgr.invoke_callback(callback_id, signalr::value(42), true);
 
     ASSERT_TRUE(callback_found);
-    ASSERT_EQ("42", callback_argument);
+    ASSERT_EQ(42, callback_argument);
     ASSERT_FALSE(callback_mgr.remove_callback(callback_id));
 }
 
 TEST(callback_manager_invoke_callback, invoke_callback_invokes_and_does_not_remove_callback_if_remove_callback_false)
 {
-    callback_manager callback_mgr{ json::value::object() };
+    callback_manager callback_mgr{ signalr::value() };
 
-    std::string callback_argument{ "" };
+    int callback_argument;
 
     auto callback_id = callback_mgr.register_callback(
-        [&callback_argument](const json::value& argument)
+        [&callback_argument](const signalr::value& argument)
     {
-        callback_argument = utility::conversions::to_utf8string(argument.serialize());
+        callback_argument = argument.as_double();
     });
 
-    auto callback_found = callback_mgr.invoke_callback(callback_id, json::value::number(42), false);
+    auto callback_found = callback_mgr.invoke_callback(callback_id, signalr::value(42), false);
 
     ASSERT_TRUE(callback_found);
-    ASSERT_EQ("42", callback_argument);
+    ASSERT_EQ(42, callback_argument);
     ASSERT_TRUE(callback_mgr.remove_callback(callback_id));
 }
 
-TEST(callback_manager_ivoke_callback, invoke_callback_returns_false_for_invalid_callback_id)
+TEST(callback_manager_invoke_callback, invoke_callback_returns_false_for_invalid_callback_id)
 {
-    callback_manager callback_mgr{ json::value::object() };
-    auto callback_found = callback_mgr.invoke_callback("42", json::value::object(), true);
+    callback_manager callback_mgr{ signalr::value() };
+    auto callback_found = callback_mgr.invoke_callback("42", signalr::value(), true);
 
     ASSERT_FALSE(callback_found);
 }
@@ -67,10 +66,10 @@ TEST(callback_manager_remove, remove_removes_callback_and_returns_true_for_valid
     auto callback_called = false;
 
     {
-        callback_manager callback_mgr{ json::value::object() };
+        callback_manager callback_mgr{ signalr::value() };
 
         auto callback_id = callback_mgr.register_callback(
-            [&callback_called](const json::value&)
+            [&callback_called](const signalr::value&)
         {
             callback_called = true;
         });
@@ -83,26 +82,26 @@ TEST(callback_manager_remove, remove_removes_callback_and_returns_true_for_valid
 
 TEST(callback_manager_remove, remove_returns_false_for_invalid_callback_id)
 {
-    callback_manager callback_mgr{ json::value::object() };
+    callback_manager callback_mgr{ signalr::value() };
     ASSERT_FALSE(callback_mgr.remove_callback("42"));
 }
 
 TEST(callback_manager_clear, clear_invokes_all_callbacks)
 {
-    callback_manager callback_mgr{ json::value::object() };
+    callback_manager callback_mgr{ signalr::value() };
     auto invocation_count = 0;
 
     for (auto i = 0; i < 10; i++)
     {
         callback_mgr.register_callback(
-            [&invocation_count](const json::value& argument)
+            [&invocation_count](const signalr::value& argument)
         {
             invocation_count++;
-            ASSERT_EQ(_XPLATSTR("42"), argument.serialize());
+            ASSERT_EQ(42, argument.as_double());
         });
     }
 
-    callback_mgr.clear(json::value::number(42));
+    callback_mgr.clear(signalr::value(42));
 
     ASSERT_EQ(10, invocation_count);
 }
@@ -113,14 +112,14 @@ TEST(callback_manager_dtor, clear_invokes_all_callbacks)
     bool parameter_correct = true;
 
     {
-        callback_manager callback_mgr{ json::value::number(42) };
+        callback_manager callback_mgr{ signalr::value(42) };
         for (auto i = 0; i < 10; i++)
         {
             callback_mgr.register_callback(
-                [&invocation_count, &parameter_correct](const json::value& argument)
+                [&invocation_count, &parameter_correct](const signalr::value& argument)
             {
                 invocation_count++;
-                parameter_correct &= argument.serialize() == _XPLATSTR("42");
+                parameter_correct &= argument.as_double() == 42;
             });
         }
     }

--- a/test/signalrclienttests/callback_manager_tests.cpp
+++ b/test/signalrclienttests/callback_manager_tests.cpp
@@ -27,7 +27,7 @@ TEST(callback_manager_invoke_callback, invoke_callback_invokes_and_removes_callb
             callback_argument = argument.as_double();
         });
 
-    auto callback_found = callback_mgr.invoke_callback(callback_id, signalr::value(42), true);
+    auto callback_found = callback_mgr.invoke_callback(callback_id, signalr::value(42.0), true);
 
     ASSERT_TRUE(callback_found);
     ASSERT_EQ(42, callback_argument);
@@ -46,7 +46,7 @@ TEST(callback_manager_invoke_callback, invoke_callback_invokes_and_does_not_remo
         callback_argument = argument.as_double();
     });
 
-    auto callback_found = callback_mgr.invoke_callback(callback_id, signalr::value(42), false);
+    auto callback_found = callback_mgr.invoke_callback(callback_id, signalr::value(42.0), false);
 
     ASSERT_TRUE(callback_found);
     ASSERT_EQ(42, callback_argument);
@@ -101,7 +101,7 @@ TEST(callback_manager_clear, clear_invokes_all_callbacks)
         });
     }
 
-    callback_mgr.clear(signalr::value(42));
+    callback_mgr.clear(signalr::value(42.0));
 
     ASSERT_EQ(10, invocation_count);
 }
@@ -112,7 +112,7 @@ TEST(callback_manager_dtor, clear_invokes_all_callbacks)
     bool parameter_correct = true;
 
     {
-        callback_manager callback_mgr{ signalr::value(42) };
+        callback_manager callback_mgr{ signalr::value(42.0) };
         for (auto i = 0; i < 10; i++)
         {
             callback_mgr.register_callback(

--- a/test/signalrclienttests/callback_manager_tests.cpp
+++ b/test/signalrclienttests/callback_manager_tests.cpp
@@ -24,7 +24,7 @@ TEST(callback_manager_invoke_callback, invoke_callback_invokes_and_removes_callb
     auto callback_id = callback_mgr.register_callback(
         [&callback_argument](const signalr::value& argument)
         {
-            callback_argument = argument.as_double();
+            callback_argument = (int)argument.as_double();
         });
 
     auto callback_found = callback_mgr.invoke_callback(callback_id, signalr::value(42.0), true);
@@ -43,7 +43,7 @@ TEST(callback_manager_invoke_callback, invoke_callback_invokes_and_does_not_remo
     auto callback_id = callback_mgr.register_callback(
         [&callback_argument](const signalr::value& argument)
     {
-        callback_argument = argument.as_double();
+        callback_argument = (int)argument.as_double();
     });
 
     auto callback_found = callback_mgr.invoke_callback(callback_id, signalr::value(42.0), false);

--- a/test/signalrclienttests/hub_connection_impl_tests.cpp
+++ b/test/signalrclienttests/hub_connection_impl_tests.cpp
@@ -305,7 +305,7 @@ TEST(stop, stop_cancels_pending_callbacks)
     mre.get();
 
     auto invoke_mre = manual_reset_event<void>();
-    hub_connection->invoke("method", signalr::value(signalr::type::array), [&invoke_mre](const signalr::value&, std::exception_ptr exception)
+    hub_connection->invoke("method", signalr::value(signalr::value_type::array), [&invoke_mre](const signalr::value&, std::exception_ptr exception)
     {
         invoke_mre.set(exception);
     });
@@ -360,7 +360,7 @@ TEST(stop, pending_callbacks_finished_if_hub_connections_goes_out_of_scope)
 
         mre.get();
 
-        hub_connection->invoke("method", signalr::value(signalr::type::array), [&invoke_mre](const signalr::value&, std::exception_ptr exception)
+        hub_connection->invoke("method", signalr::value(signalr::value_type::array), [&invoke_mre](const signalr::value&, std::exception_ptr exception)
         {
             invoke_mre.set(exception);
         });
@@ -447,7 +447,7 @@ TEST(send, creates_correct_payload)
 
     mre.get();
 
-    hub_connection->send("method", signalr::value(signalr::type::array), [&mre](std::exception_ptr exception)
+    hub_connection->send("method", signalr::value(signalr::value_type::array), [&mre](std::exception_ptr exception)
     {
         mre.set(exception);
     });
@@ -492,7 +492,7 @@ TEST(send, does_not_wait_for_server_response)
     mre.get();
 
     // wont block waiting for server response
-    hub_connection->send("method", signalr::value(signalr::type::array), [&mre](std::exception_ptr exception)
+    hub_connection->send("method", signalr::value(signalr::value_type::array), [&mre](std::exception_ptr exception)
     {
         mre.set(exception);
     });
@@ -528,7 +528,7 @@ TEST(invoke, creates_correct_payload)
 
     mre.get();
 
-    hub_connection->invoke("method", signalr::value(signalr::type::array), [&mre](const signalr::value&, std::exception_ptr exception)
+    hub_connection->invoke("method", signalr::value(signalr::value_type::array), [&mre](const signalr::value&, std::exception_ptr exception)
     {
         mre.set(exception);
     });
@@ -571,7 +571,7 @@ TEST(invoke, callback_not_called_if_send_throws)
 
     mre.get();
 
-    hub_connection->invoke("method", signalr::value(signalr::type::array), [&mre](const signalr::value&, std::exception_ptr exception)
+    hub_connection->invoke("method", signalr::value(signalr::value_type::array), [&mre](const signalr::value&, std::exception_ptr exception)
     {
         mre.set(exception);
     });
@@ -632,7 +632,7 @@ TEST(invoke, invoke_returns_value_returned_from_the_server)
     mre.get();
 
     auto invoke_mre = manual_reset_event<signalr::value>();
-    hub_connection->invoke("method", signalr::value(signalr::type::array), [&invoke_mre](const signalr::value& message, std::exception_ptr exception)
+    hub_connection->invoke("method", signalr::value(signalr::value_type::array), [&invoke_mre](const signalr::value& message, std::exception_ptr exception)
     {
         if (exception)
         {
@@ -697,7 +697,7 @@ TEST(invoke, invoke_propagates_errors_from_server_as_hub_exceptions)
 
     mre.get();
 
-    hub_connection->invoke("method", signalr::value(signalr::type::array), [&mre](const signalr::value&, std::exception_ptr exception)
+    hub_connection->invoke("method", signalr::value(signalr::value_type::array), [&mre](const signalr::value&, std::exception_ptr exception)
     {
         mre.set(exception);
     });
@@ -750,7 +750,7 @@ TEST(invoke, unblocks_task_when_server_completes_call)
 
     mre.get();
 
-    hub_connection->invoke("method", signalr::value(signalr::type::array), [&mre](const signalr::value&, std::exception_ptr exception)
+    hub_connection->invoke("method", signalr::value(signalr::value_type::array), [&mre](const signalr::value&, std::exception_ptr exception)
     {
         mre.set(exception);
     });
@@ -850,7 +850,7 @@ TEST(invoke_void, invoke_creates_runtime_error)
 
    mre.get();
 
-   hub_connection->invoke("method", signalr::value(signalr::type::array), [&mre](const signalr::value&, std::exception_ptr exception)
+   hub_connection->invoke("method", signalr::value(signalr::value_type::array), [&mre](const signalr::value&, std::exception_ptr exception)
    {
        mre.set(exception);
    });
@@ -960,7 +960,7 @@ TEST(invoke, invoke_throws_when_the_underlying_connection_is_not_valid)
     auto hub_connection = create_hub_connection();
 
     auto mre = manual_reset_event<void>();
-    hub_connection->invoke("method", signalr::value(signalr::type::array), [&mre](const signalr::value&, std::exception_ptr exception)
+    hub_connection->invoke("method", signalr::value(signalr::value_type::array), [&mre](const signalr::value&, std::exception_ptr exception)
     {
         mre.set(exception);
     });
@@ -981,7 +981,7 @@ TEST(invoke, send_throws_when_the_underlying_connection_is_not_valid)
     auto hub_connection = create_hub_connection();
 
     auto mre = manual_reset_event<void>();
-    hub_connection->invoke("method", signalr::value(signalr::type::array), [&mre](const signalr::value&, std::exception_ptr exception)
+    hub_connection->invoke("method", signalr::value(signalr::value_type::array), [&mre](const signalr::value&, std::exception_ptr exception)
     {
         mre.set(exception);
     });


### PR DESCRIPTION
Changed `signalr::type` enum to `signalr::value_type`. GCC complained about `signalr::type signalr::value::type()` having the same name.