### PR TITLE
Fix leak on assignment

### DIFF
--- a/include/signalrclient/signalr_value.h
+++ b/include/signalrclient/signalr_value.h
@@ -184,5 +184,7 @@ namespace signalr
         };
 
         storage mStorage;
+
+        void destruct_internals();
     };
 }

--- a/src/signalrclient/json_hub_protocol.cpp
+++ b/src/signalrclient/json_hub_protocol.cpp
@@ -22,7 +22,7 @@ namespace signalr
         auto pos = message.find(record_separator, offset);
         while (pos != std::string::npos)
         {
-            auto hub_message = parse_message(message.substr(offset, pos - offset));
+            auto hub_message = parse_message(message.c_str() + offset, pos - offset);
             vec.push_back(std::move(hub_message));
 
             offset = pos + 1;
@@ -33,13 +33,13 @@ namespace signalr
         return vec;
     }
 
-    signalr::value json_hub_protocol::parse_message(const std::string& message) const
+    signalr::value json_hub_protocol::parse_message(const char* begin, size_t length) const
     {
         Json::Value root;
         auto reader = getJsonReader();
         std::string errors;
 
-        if (!reader->parse(message.c_str(), message.c_str() + message.size(), &root, &errors))
+        if (!reader->parse(begin, begin + length, &root, &errors))
         {
             throw signalr_exception(errors);
         }

--- a/src/signalrclient/json_hub_protocol.h
+++ b/src/signalrclient/json_hub_protocol.h
@@ -24,7 +24,7 @@ namespace signalr
 
         ~json_hub_protocol() {}
     private:
-        signalr::value parse_message(const std::string&) const;
+        signalr::value parse_message(const char* begin, size_t length) const;
 
         std::string m_protocol_name = "json";
     };

--- a/src/signalrclient/signalr_value.cpp
+++ b/src/signalrclient/signalr_value.cpp
@@ -152,6 +152,11 @@ namespace signalr
 
     value::~value()
     {
+        destruct_internals();
+    }
+
+    void value::destruct_internals()
+    {
         switch (mType)
         {
         case value_type::array:
@@ -170,6 +175,8 @@ namespace signalr
 
     value& value::operator=(const value& rhs)
     {
+        destruct_internals();
+
         mType = rhs.mType;
         switch (mType)
         {
@@ -197,6 +204,8 @@ namespace signalr
 
     value& value::operator=(value&& rhs) noexcept
     {
+        destruct_internals();
+
         mType = std::move(rhs.mType);
         switch (mType)
         {


### PR DESCRIPTION
Because we're using a union for the internal storage, we need to manually control the destruction of the storage. One case that was missed was during assignment if `this` already contained an object then we wouldn't destruct the internal storage when it was being replaced.

Also, snuck in a small change to remove a `substr` in the `json_hub_protocol`. Small perf gains 😄 