### PR TITLE
Fix linking error when using cpprestsdk from apt

### DIFF
--- a/src/signalrclient/CMakeLists.txt
+++ b/src/signalrclient/CMakeLists.txt
@@ -41,7 +41,7 @@ else()
     )
   elseif(NOT WIN32)
     target_link_libraries(signalrclient
-      PUBLIC ${CPPREST_LIB}
+      PUBLIC ${CPPREST_LIB} Boost::system
       PRIVATE OpenSSL::SSL
     )
   else()

--- a/test/signalrclienttests/CMakeLists.txt
+++ b/test/signalrclienttests/CMakeLists.txt
@@ -25,5 +25,5 @@ include_directories(
 add_executable (signalrclienttests ${SOURCES})
 
 find_package(Boost REQUIRED COMPONENTS system)
-target_link_libraries(signalrclienttests gtest signalrclient ${CPPREST_LIB} Boost::system)
+target_link_libraries(signalrclienttests gtest signalrclient Boost::system)
 add_test(NAME signalrclienttests COMMAND signalrclienttests)

--- a/test/signalrclienttests/CMakeLists.txt
+++ b/test/signalrclienttests/CMakeLists.txt
@@ -24,6 +24,5 @@ include_directories(
 
 add_executable (signalrclienttests ${SOURCES})
 
-find_package(Boost REQUIRED COMPONENTS system)
-target_link_libraries(signalrclienttests gtest signalrclient Boost::system)
+target_link_libraries(signalrclienttests gtest signalrclient)
 add_test(NAME signalrclienttests COMMAND signalrclienttests)

--- a/test/signalrclienttests/CMakeLists.txt
+++ b/test/signalrclienttests/CMakeLists.txt
@@ -24,5 +24,6 @@ include_directories(
 
 add_executable (signalrclienttests ${SOURCES})
 
-target_link_libraries(signalrclienttests gtest signalrclient ${CPPREST_LIB})
+find_package(Boost REQUIRED COMPONENTS system)
+target_link_libraries(signalrclienttests gtest signalrclient ${CPPREST_LIB} Boost::system)
 add_test(NAME signalrclienttests COMMAND signalrclienttests)


### PR DESCRIPTION
When compile the client library with cpprestsdk from apt(maybe there are some other manual ways besides vcpkg), you will get the following link error:

```
/usr/bin/ld: CMakeFiles/signalrclienttests.dir/connection_impl_tests.cpp.o: undefined reference to symbol '_ZN5boost6system15system_categoryEv'
```

The compiler is `gcc (Ubuntu 7.4.0-1ubuntu1~18.04.1) 7.4.0`

This commit fixed the problem.