### PR TITLE
Disable C4378 for x86-Release

### DIFF
--- a/third_party_code/jsoncpp/jsoncpp.cpp
+++ b/third_party_code/jsoncpp/jsoncpp.cpp
@@ -3326,6 +3326,7 @@ double Value::asDouble() const {
   JSON_FAIL_MESSAGE("Value is not convertible to double.");
 }
 
+#pragma warning(disable:4738)
 float Value::asFloat() const {
   switch (type_) {
   case intValue:
@@ -3348,6 +3349,7 @@ float Value::asFloat() const {
   }
   JSON_FAIL_MESSAGE("Value is not convertible to float.");
 }
+#pragma warning(default:4738)
 
 bool Value::asBool() const {
   switch (type_) {

--- a/third_party_code/jsoncpp/jsoncpp.cpp
+++ b/third_party_code/jsoncpp/jsoncpp.cpp
@@ -70,7 +70,7 @@ license you like.
 
 
 #pragma warning( push, 0 )
-#pragma warning( disable: 4702 )
+#pragma warning( disable: 4702; disable: 4738 )
 
 
 
@@ -3326,7 +3326,6 @@ double Value::asDouble() const {
   JSON_FAIL_MESSAGE("Value is not convertible to double.");
 }
 
-#pragma warning(disable:4738)
 float Value::asFloat() const {
   switch (type_) {
   case intValue:
@@ -3349,7 +3348,6 @@ float Value::asFloat() const {
   }
   JSON_FAIL_MESSAGE("Value is not convertible to float.");
 }
-#pragma warning(default:4738)
 
 bool Value::asBool() const {
   switch (type_) {


### PR DESCRIPTION
Disable the warning when a 32-bit float is returned which is treated as an error and prevents x86-Release config from building.