### PR TITLE
Crash if user not define log writer

### DIFF
--- a/src/signalrclient/logger.cpp
+++ b/src/signalrclient/logger.cpp
@@ -23,7 +23,7 @@ namespace signalr
 
     void logger::log(trace_level level, const std::string& entry) const
     {
-        if ((level & m_trace_level) != trace_level::none)
+        if ((level & m_trace_level) != trace_level::none && m_log_writer)
         {
             try
             {


### PR DESCRIPTION
Crash may occur if user create connection like this:
`auto connection = hub_connection_builder::create(url).build();`

And if connection lost from server, cable unplug or something else. On disconnection try write to log without writer.