### PR TITLE
Add scheduler abstraction + default impl

### DIFF
--- a/include/signalrclient/connection.h
+++ b/include/signalrclient/connection.h
@@ -11,6 +11,7 @@
 #include "trace_level.h"
 #include "log_writer.h"
 #include "signalr_client_config.h"
+#include "scheduler.h"
 #include "transfer_format.h"
 
 namespace signalr
@@ -22,7 +23,7 @@ namespace signalr
     public:
         typedef std::function<void __cdecl(const std::string&)> message_received_handler;
 
-        SIGNALRCLIENT_API explicit connection(const std::string& url, trace_level trace_level = trace_level::info, std::shared_ptr<log_writer> log_writer = nullptr);
+        SIGNALRCLIENT_API explicit connection(const std::string& url, std::shared_ptr<scheduler> scheduler, trace_level trace_level = trace_level::info, std::shared_ptr<log_writer> log_writer = nullptr);
 
         SIGNALRCLIENT_API ~connection();
 

--- a/include/signalrclient/connection.h
+++ b/include/signalrclient/connection.h
@@ -11,7 +11,6 @@
 #include "trace_level.h"
 #include "log_writer.h"
 #include "signalr_client_config.h"
-#include "scheduler.h"
 #include "transfer_format.h"
 
 namespace signalr

--- a/include/signalrclient/connection.h
+++ b/include/signalrclient/connection.h
@@ -22,7 +22,7 @@ namespace signalr
     public:
         typedef std::function<void __cdecl(const std::string&)> message_received_handler;
 
-        SIGNALRCLIENT_API explicit connection(const std::string& url, std::shared_ptr<scheduler> scheduler, trace_level trace_level = trace_level::info, std::shared_ptr<log_writer> log_writer = nullptr);
+        SIGNALRCLIENT_API explicit connection(const std::string& url, trace_level trace_level = trace_level::info, std::shared_ptr<log_writer> log_writer = nullptr);
 
         SIGNALRCLIENT_API ~connection();
 

--- a/include/signalrclient/hub_connection.h
+++ b/include/signalrclient/hub_connection.h
@@ -12,6 +12,7 @@
 #include "log_writer.h"
 #include "signalr_client_config.h"
 #include "signalr_value.h"
+#include "../include/signalrclient/scheduler.h"
 
 namespace signalr
 {
@@ -54,7 +55,7 @@ namespace signalr
     private:
         friend class hub_connection_builder;
 
-        explicit hub_connection(const std::string& url, trace_level trace_level = trace_level::info,
+        explicit hub_connection(const std::string& url, std::shared_ptr<scheduler> scheduler, trace_level trace_level = trace_level::info,
             std::shared_ptr<log_writer> log_writer = nullptr, std::shared_ptr<http_client> http_client = nullptr,
             std::function<std::shared_ptr<websocket_client>(const signalr_client_config&)> websocket_factory = nullptr, bool skip_negotiation = false);
 

--- a/include/signalrclient/hub_connection.h
+++ b/include/signalrclient/hub_connection.h
@@ -54,7 +54,7 @@ namespace signalr
     private:
         friend class hub_connection_builder;
 
-        explicit hub_connection(const std::string& url, std::shared_ptr<scheduler> scheduler, trace_level trace_level = trace_level::info,
+        explicit hub_connection(const std::string& url, trace_level trace_level = trace_level::info,
             std::shared_ptr<log_writer> log_writer = nullptr, std::shared_ptr<http_client> http_client = nullptr,
             std::function<std::shared_ptr<websocket_client>(const signalr_client_config&)> websocket_factory = nullptr, bool skip_negotiation = false);
 

--- a/include/signalrclient/hub_connection.h
+++ b/include/signalrclient/hub_connection.h
@@ -55,7 +55,7 @@ namespace signalr
         friend class hub_connection_builder;
 
         explicit hub_connection(const std::string& url, trace_level trace_level = trace_level::info,
-            std::shared_ptr<log_writer> log_writer = nullptr, std::shared_ptr<http_client> http_client = nullptr,
+            std::shared_ptr<log_writer> log_writer = nullptr, std::function<std::shared_ptr<http_client>(const signalr_client_config&)> http_client_factory = nullptr,
             std::function<std::shared_ptr<websocket_client>(const signalr_client_config&)> websocket_factory = nullptr, bool skip_negotiation = false);
 
         std::shared_ptr<hub_connection_impl> m_pImpl;

--- a/include/signalrclient/hub_connection.h
+++ b/include/signalrclient/hub_connection.h
@@ -12,7 +12,6 @@
 #include "log_writer.h"
 #include "signalr_client_config.h"
 #include "signalr_value.h"
-#include "../include/signalrclient/scheduler.h"
 
 namespace signalr
 {

--- a/include/signalrclient/hub_connection_builder.h
+++ b/include/signalrclient/hub_connection_builder.h
@@ -31,7 +31,7 @@ namespace signalr
 
         SIGNALRCLIENT_API hub_connection_builder& with_websocket_factory(std::function<std::shared_ptr<websocket_client>(const signalr_client_config&)> factory);
 
-        SIGNALRCLIENT_API hub_connection_builder& with_http_client(std::shared_ptr<http_client> http_client);
+        SIGNALRCLIENT_API hub_connection_builder& with_http_client_factory(std::function<std::shared_ptr<http_client>(const signalr_client_config&)> http_client_factory);
 
         SIGNALRCLIENT_API hub_connection_builder& skip_negotiation(bool skip = true);
 
@@ -43,7 +43,7 @@ namespace signalr
         std::shared_ptr<log_writer> m_logger;
         trace_level m_log_level;
         std::function<std::shared_ptr<websocket_client>(const signalr_client_config&)> m_websocket_factory;
-        std::shared_ptr<http_client> m_http_client;
+        std::function<std::shared_ptr<http_client>(const signalr_client_config&)> m_http_client_factory;
         bool m_skip_negotiation = false;
     };
 }

--- a/include/signalrclient/scheduler.h
+++ b/include/signalrclient/scheduler.h
@@ -1,0 +1,29 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#pragma once
+
+#include <condition_variable>
+#include <exception>
+#include <functional>
+#include <mutex>
+#include <vector>
+#include <chrono>
+
+namespace signalr
+{
+    typedef std::function<void()> signalr_base_cb;
+    typedef std::function<void(std::exception_ptr)> signalr_cb;
+    typedef std::function<void(std::string, std::exception_ptr)> signalr_message_cb;
+
+    struct scheduler
+    {
+        virtual void schedule(const signalr_cb& cb, std::chrono::milliseconds delay) = 0;
+        virtual void schedule(const signalr_cb& cb, std::exception_ptr, std::chrono::milliseconds delay) = 0;
+        virtual void schedule(const signalr_message_cb& cb, std::string, std::chrono::milliseconds delay) = 0;
+        virtual void schedule(const signalr_message_cb& cb, std::exception_ptr, std::chrono::milliseconds delay) = 0;
+        virtual void schedule(const signalr_base_cb& cb, std::chrono::milliseconds delay) = 0;
+
+        virtual ~scheduler() {}
+    };
+}

--- a/include/signalrclient/scheduler.h
+++ b/include/signalrclient/scheduler.h
@@ -18,11 +18,11 @@ namespace signalr
 
     struct scheduler
     {
-        virtual void schedule(const signalr_cb& cb, std::chrono::milliseconds delay) = 0;
-        virtual void schedule(const signalr_cb& cb, std::exception_ptr, std::chrono::milliseconds delay) = 0;
-        virtual void schedule(const signalr_message_cb& cb, std::string, std::chrono::milliseconds delay) = 0;
-        virtual void schedule(const signalr_message_cb& cb, std::exception_ptr, std::chrono::milliseconds delay) = 0;
-        virtual void schedule(const signalr_base_cb& cb, std::chrono::milliseconds delay) = 0;
+        virtual void schedule(const signalr_cb& cb, std::chrono::milliseconds delay = std::chrono::milliseconds::zero()) = 0;
+        virtual void schedule(const signalr_cb& cb, std::exception_ptr, std::chrono::milliseconds delay = std::chrono::milliseconds::zero()) = 0;
+        virtual void schedule(const signalr_message_cb& cb, std::string, std::chrono::milliseconds delay = std::chrono::milliseconds::zero()) = 0;
+        virtual void schedule(const signalr_message_cb& cb, std::exception_ptr, std::chrono::milliseconds delay = std::chrono::milliseconds::zero()) = 0;
+        virtual void schedule(const signalr_base_cb& cb, std::chrono::milliseconds delay = std::chrono::milliseconds::zero()) = 0;
 
         virtual ~scheduler() {}
     };

--- a/include/signalrclient/scheduler.h
+++ b/include/signalrclient/scheduler.h
@@ -18,7 +18,11 @@ namespace signalr
 
     struct scheduler
     {
-        virtual void schedule(const signalr_cb& cb, std::chrono::milliseconds delay = std::chrono::milliseconds::zero()) = 0;
+        virtual void schedule(const signalr_cb& cb, std::chrono::milliseconds delay = std::chrono::milliseconds::zero())
+        {
+            schedule(cb, nullptr, delay);
+        }
+
         virtual void schedule(const signalr_cb& cb, std::exception_ptr, std::chrono::milliseconds delay = std::chrono::milliseconds::zero()) = 0;
         virtual void schedule(const signalr_message_cb& cb, std::string, std::chrono::milliseconds delay = std::chrono::milliseconds::zero()) = 0;
         virtual void schedule(const signalr_message_cb& cb, std::exception_ptr, std::chrono::milliseconds delay = std::chrono::milliseconds::zero()) = 0;

--- a/include/signalrclient/scheduler.h
+++ b/include/signalrclient/scheduler.h
@@ -6,6 +6,7 @@
 
 #include <exception>
 #include <functional>
+#include <string>
 #include <chrono>
 
 namespace signalr

--- a/include/signalrclient/scheduler.h
+++ b/include/signalrclient/scheduler.h
@@ -1,13 +1,11 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 #pragma once
 
-#include <condition_variable>
 #include <exception>
 #include <functional>
-#include <mutex>
-#include <vector>
 #include <chrono>
 
 namespace signalr

--- a/include/signalrclient/scheduler.h
+++ b/include/signalrclient/scheduler.h
@@ -23,9 +23,21 @@ namespace signalr
             schedule(cb, nullptr, delay);
         }
 
-        virtual void schedule(const signalr_cb& cb, std::exception_ptr, std::chrono::milliseconds delay = std::chrono::milliseconds::zero()) = 0;
-        virtual void schedule(const signalr_message_cb& cb, std::string, std::chrono::milliseconds delay = std::chrono::milliseconds::zero()) = 0;
-        virtual void schedule(const signalr_message_cb& cb, std::exception_ptr, std::chrono::milliseconds delay = std::chrono::milliseconds::zero()) = 0;
+        virtual void schedule(const signalr_cb& cb, std::exception_ptr exception, std::chrono::milliseconds delay = std::chrono::milliseconds::zero())
+        {
+            schedule([cb, exception]() { cb(exception); }, delay);
+        }
+
+        virtual void schedule(const signalr_message_cb& cb, std::string message, std::chrono::milliseconds delay = std::chrono::milliseconds::zero())
+        {
+            schedule([cb, message]() { cb(message, nullptr); }, delay);
+        }
+
+        virtual void schedule(const signalr_message_cb& cb, std::exception_ptr exception, std::chrono::milliseconds delay = std::chrono::milliseconds::zero())
+        {
+            schedule([cb, exception]() { cb("", exception); }, delay);
+        }
+
         virtual void schedule(const signalr_base_cb& cb, std::chrono::milliseconds delay = std::chrono::milliseconds::zero()) = 0;
 
         virtual ~scheduler() {}

--- a/include/signalrclient/scheduler.h
+++ b/include/signalrclient/scheduler.h
@@ -12,31 +12,9 @@
 namespace signalr
 {
     typedef std::function<void()> signalr_base_cb;
-    typedef std::function<void(std::exception_ptr)> signalr_cb;
-    typedef std::function<void(std::string, std::exception_ptr)> signalr_message_cb;
 
     struct scheduler
     {
-        virtual void schedule(const signalr_cb& cb, std::chrono::milliseconds delay = std::chrono::milliseconds::zero())
-        {
-            schedule(cb, nullptr, delay);
-        }
-
-        virtual void schedule(const signalr_cb& cb, std::exception_ptr exception, std::chrono::milliseconds delay = std::chrono::milliseconds::zero())
-        {
-            schedule([cb, exception]() { cb(exception); }, delay);
-        }
-
-        virtual void schedule(const signalr_message_cb& cb, std::string message, std::chrono::milliseconds delay = std::chrono::milliseconds::zero())
-        {
-            schedule([cb, message]() { cb(message, nullptr); }, delay);
-        }
-
-        virtual void schedule(const signalr_message_cb& cb, std::exception_ptr exception, std::chrono::milliseconds delay = std::chrono::milliseconds::zero())
-        {
-            schedule([cb, exception]() { cb("", exception); }, delay);
-        }
-
         virtual void schedule(const signalr_base_cb& cb, std::chrono::milliseconds delay = std::chrono::milliseconds::zero()) = 0;
 
         virtual ~scheduler() {}

--- a/include/signalrclient/scheduler.h
+++ b/include/signalrclient/scheduler.h
@@ -6,7 +6,6 @@
 
 #include <exception>
 #include <functional>
-#include <string>
 #include <chrono>
 
 namespace signalr

--- a/include/signalrclient/signalr_client_config.h
+++ b/include/signalrclient/signalr_client_config.h
@@ -15,6 +15,8 @@
 #include "_exports.h"
 #include <map>
 #include <string>
+#include "scheduler.h"
+#include "../src/signalrclient/signalr_default_scheduler.h"
 
 namespace signalr
 {
@@ -39,6 +41,8 @@ namespace signalr
         SIGNALRCLIENT_API const std::map<std::string, std::string>& __cdecl get_http_headers() const noexcept;
         SIGNALRCLIENT_API std::map<std::string, std::string>& __cdecl get_http_headers() noexcept;
         SIGNALRCLIENT_API void __cdecl set_http_headers(const std::map<std::string, std::string>& http_headers);
+        SIGNALRCLIENT_API void __cdecl set_scheduler(std::shared_ptr<scheduler> scheduler);
+        SIGNALRCLIENT_API std::shared_ptr<scheduler> __cdecl get_scheduler() const noexcept;
 
     private:
 #ifdef USE_CPPRESTSDK
@@ -46,5 +50,6 @@ namespace signalr
         web::websockets::client::websocket_client_config m_websocket_client_config;
 #endif
         std::map<std::string, std::string> m_http_headers;
+        std::shared_ptr<scheduler> m_scheduler = std::make_shared<signalr_default_scheduler>();
     };
 }

--- a/include/signalrclient/signalr_client_config.h
+++ b/include/signalrclient/signalr_client_config.h
@@ -16,7 +16,6 @@
 #include <map>
 #include <string>
 #include "scheduler.h"
-#include "../src/signalrclient/signalr_default_scheduler.h"
 
 namespace signalr
 {
@@ -38,6 +37,8 @@ namespace signalr
         SIGNALRCLIENT_API void __cdecl set_websocket_client_config(const web::websockets::client::websocket_client_config& websocket_client_config);
 #endif
 
+        SIGNALRCLIENT_API __cdecl signalr_client_config();
+
         SIGNALRCLIENT_API const std::map<std::string, std::string>& __cdecl get_http_headers() const noexcept;
         SIGNALRCLIENT_API std::map<std::string, std::string>& __cdecl get_http_headers() noexcept;
         SIGNALRCLIENT_API void __cdecl set_http_headers(const std::map<std::string, std::string>& http_headers);
@@ -50,6 +51,6 @@ namespace signalr
         web::websockets::client::websocket_client_config m_websocket_client_config;
 #endif
         std::map<std::string, std::string> m_http_headers;
-        std::shared_ptr<scheduler> m_scheduler = std::make_shared<signalr_default_scheduler>();
+        std::shared_ptr<scheduler> m_scheduler;
     };
 }

--- a/include/signalrclient/signalr_client_config.h
+++ b/include/signalrclient/signalr_client_config.h
@@ -43,7 +43,7 @@ namespace signalr
         SIGNALRCLIENT_API std::map<std::string, std::string>& __cdecl get_http_headers() noexcept;
         SIGNALRCLIENT_API void __cdecl set_http_headers(const std::map<std::string, std::string>& http_headers);
         SIGNALRCLIENT_API void __cdecl set_scheduler(std::shared_ptr<scheduler> scheduler);
-        SIGNALRCLIENT_API std::shared_ptr<scheduler> __cdecl get_scheduler() const noexcept;
+        SIGNALRCLIENT_API const std::shared_ptr<scheduler>& __cdecl get_scheduler() const noexcept;
 
     private:
 #ifdef USE_CPPRESTSDK

--- a/include/signalrclient/signalr_client_config.h
+++ b/include/signalrclient/signalr_client_config.h
@@ -16,6 +16,7 @@
 #include <map>
 #include <string>
 #include "scheduler.h"
+#include <memory>
 
 namespace signalr
 {

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -11,7 +11,7 @@ eval $* &
 PID=$!
 
 # Timeout duration
-TIME=120
+TIME=240
 
 while (($TIME > 0)); do
   # polling interval
@@ -34,4 +34,4 @@ done
 kill -9 $PID
 
 echo "Process took too long"
-exit $EXITCODE
+exit 1

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -11,7 +11,7 @@ eval $* &
 PID=$!
 
 # Timeout duration
-TIME=240
+TIME=800
 
 while (($TIME > 0)); do
   # polling interval

--- a/src/signalrclient/CMakeLists.txt
+++ b/src/signalrclient/CMakeLists.txt
@@ -20,6 +20,7 @@ set (SOURCES
   transport_factory.cpp
   url_builder.cpp
   websocket_transport.cpp
+  signalr_default_scheduler.cpp
   ../../third_party_code/cpprestsdk/uri.cpp
   ../../third_party_code/cpprestsdk/uri_builder.cpp
 )

--- a/src/signalrclient/connection.cpp
+++ b/src/signalrclient/connection.cpp
@@ -9,8 +9,8 @@
 
 namespace signalr
 {
-    connection::connection(const std::string& url, std::shared_ptr<scheduler> scheduler, trace_level trace_level, std::shared_ptr<log_writer> log_writer)
-        : m_pImpl(connection_impl::create(url, scheduler, trace_level, std::move(log_writer)))
+    connection::connection(const std::string& url, trace_level trace_level, std::shared_ptr<log_writer> log_writer)
+        : m_pImpl(connection_impl::create(url, trace_level, std::move(log_writer)))
     {}
 
     // Do NOT remove this destructor. Letting the compiler generate and inline the default dtor may lead to

--- a/src/signalrclient/connection.cpp
+++ b/src/signalrclient/connection.cpp
@@ -9,8 +9,8 @@
 
 namespace signalr
 {
-    connection::connection(const std::string& url, trace_level trace_level, std::shared_ptr<log_writer> log_writer)
-        : m_pImpl(connection_impl::create(url, trace_level, std::move(log_writer)))
+    connection::connection(const std::string& url, std::shared_ptr<scheduler> scheduler, trace_level trace_level, std::shared_ptr<log_writer> log_writer)
+        : m_pImpl(connection_impl::create(url, scheduler, trace_level, std::move(log_writer)))
     {}
 
     // Do NOT remove this destructor. Letting the compiler generate and inline the default dtor may lead to

--- a/src/signalrclient/connection_impl.cpp
+++ b/src/signalrclient/connection_impl.cpp
@@ -143,13 +143,12 @@ namespace signalr
             m_connection_id = "";
         }
 
-        auto scheduler = m_signalr_client_config.get_scheduler();
-        if (!scheduler)
+        m_scheduler = m_signalr_client_config.get_scheduler();
+        if (!m_scheduler)
         {
-            scheduler = std::make_shared<signalr_default_scheduler>();
-            m_signalr_client_config.set_scheduler(scheduler);
+            m_scheduler = std::make_shared<signalr_default_scheduler>();
+            m_signalr_client_config.set_scheduler(m_scheduler);
         }
-        m_event_loop = scheduler;
 
         start_negotiate(m_base_url, 0, callback);
     }
@@ -414,7 +413,7 @@ namespace signalr
                 }
             });
 
-        timer(m_event_loop, [disconnect_cts, connect_request_done, connect_request_lock, callback](std::chrono::milliseconds duration) {
+        timer(m_scheduler, [disconnect_cts, connect_request_done, connect_request_lock, callback](std::chrono::milliseconds duration) {
             bool run_callback = false;
             {
                 std::lock_guard<std::mutex> lock(*connect_request_lock);

--- a/src/signalrclient/connection_impl.cpp
+++ b/src/signalrclient/connection_impl.cpp
@@ -424,7 +424,7 @@ namespace signalr
                     *connect_request_done = true;
                     run_callback = true;
                 }
-            }
+            } // unlock
 
             // if the disconnect_cts is canceled it means that the connection has been stopped or went out of scope in
             // which case we should not throw due to timeout.

--- a/src/signalrclient/connection_impl.cpp
+++ b/src/signalrclient/connection_impl.cpp
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 #include "stdafx.h"
-#include <thread>
 #include <algorithm>
 #include "constants.h"
 #include "connection_impl.h"
@@ -20,19 +19,19 @@
 
 namespace signalr
 {
-    std::shared_ptr<connection_impl> connection_impl::create(const std::string& url, trace_level trace_level, const std::shared_ptr<log_writer>& log_writer)
+    std::shared_ptr<connection_impl> connection_impl::create(const std::string& url, std::shared_ptr<scheduler> scheduler, trace_level trace_level, const std::shared_ptr<log_writer>& log_writer)
     {
-        return connection_impl::create(url, trace_level, log_writer, nullptr, nullptr, false);
+        return connection_impl::create(url, scheduler, trace_level, log_writer, nullptr, nullptr, false);
     }
 
-    std::shared_ptr<connection_impl> connection_impl::create(const std::string& url, trace_level trace_level, const std::shared_ptr<log_writer>& log_writer,
+    std::shared_ptr<connection_impl> connection_impl::create(const std::string& url, std::shared_ptr<scheduler> scheduler, trace_level trace_level, const std::shared_ptr<log_writer>& log_writer,
         std::shared_ptr<http_client> http_client, std::function<std::shared_ptr<websocket_client>(const signalr_client_config&)> websocket_factory, const bool skip_negotiation)
     {
-        return std::shared_ptr<connection_impl>(new connection_impl(url, trace_level,
+        return std::shared_ptr<connection_impl>(new connection_impl(url, scheduler, trace_level,
             log_writer ? log_writer : std::make_shared<trace_log_writer>(), http_client, websocket_factory, skip_negotiation));
     }
 
-    connection_impl::connection_impl(const std::string& url, trace_level trace_level, const std::shared_ptr<log_writer>& log_writer,
+    connection_impl::connection_impl(const std::string& url, std::shared_ptr<scheduler> scheduler, trace_level trace_level, const std::shared_ptr<log_writer>& log_writer,
         std::unique_ptr<http_client> http_client, std::unique_ptr<transport_factory> transport_factory, const bool skip_negotiation)
         : m_base_url(url), m_connection_state(connection_state::disconnected), m_logger(log_writer, trace_level), m_transport(nullptr),
         m_transport_factory(std::move(transport_factory)), m_skip_negotiation(skip_negotiation), m_message_received([](const std::string&) noexcept {}), m_disconnected([]() noexcept {})
@@ -49,7 +48,7 @@ namespace signalr
         }
     }
 
-    connection_impl::connection_impl(const std::string& url, trace_level trace_level, const std::shared_ptr<log_writer>& log_writer,
+    connection_impl::connection_impl(const std::string& url, std::shared_ptr<scheduler> scheduler, trace_level trace_level, const std::shared_ptr<log_writer>& log_writer,
         std::shared_ptr<http_client> http_client, std::function<std::shared_ptr<websocket_client>(const signalr_client_config&)> websocket_factory, const bool skip_negotiation)
         : m_base_url(url), m_connection_state(connection_state::disconnected), m_logger(log_writer, trace_level), m_transport(nullptr), m_skip_negotiation(skip_negotiation),
         m_message_received([](const std::string&) noexcept {}), m_disconnected([]() noexcept {})
@@ -73,6 +72,7 @@ namespace signalr
         }
 
         m_transport_factory = std::unique_ptr<transport_factory>(new transport_factory(m_http_client, websocket_factory));
+        m_event_loop = scheduler;
     }
 
     connection_impl::~connection_impl()
@@ -157,7 +157,7 @@ namespace signalr
         }
 
         std::weak_ptr<connection_impl> weak_connection = shared_from_this();
-        const auto& token = m_disconnect_cts;
+        const auto token = m_disconnect_cts;
 
         const auto transport_started = [weak_connection, callback, token](std::shared_ptr<transport> transport, std::exception_ptr exception)
         {
@@ -320,7 +320,7 @@ namespace signalr
         std::shared_ptr<std::mutex> connect_request_lock = std::make_shared<std::mutex>();
 
         auto weak_connection = std::weak_ptr<connection_impl>(connection);
-        const auto& disconnect_cts = m_disconnect_cts;
+        const auto disconnect_cts = m_disconnect_cts;
         const auto& logger = m_logger;
 
         auto transport = connection->m_transport_factory->create_transport(
@@ -406,10 +406,7 @@ namespace signalr
                 }
             });
 
-        std::thread([disconnect_cts, connect_request_done, connect_request_lock, callback, weak_connection]()
-        {
-            disconnect_cts->wait(5000);
-
+        m_event_loop->schedule([disconnect_cts, connect_request_done, connect_request_lock, callback]() {
             bool run_callback = false;
             {
                 std::lock_guard<std::mutex> lock(*connect_request_lock);
@@ -438,7 +435,41 @@ namespace signalr
                     callback({}, std::make_exception_ptr(signalr_exception("transport timed out when trying to connect")));
                 }
             }
-        }).detach();
+        }, std::chrono::seconds(5));
+
+        //std::thread([disconnect_cts, connect_request_done, connect_request_lock, callback, weak_connection]()
+        //{
+        //    disconnect_cts->wait(5000);
+
+        //    bool run_callback = false;
+        //    {
+        //        std::lock_guard<std::mutex> lock(*connect_request_lock);
+        //        // no op after connection started successfully
+        //        if (*connect_request_done == false)
+        //        {
+        //            *connect_request_done = true;
+        //            run_callback = true;
+        //        }
+        //    }
+
+        //    // if the disconnect_cts is canceled it means that the connection has been stopped or went out of scope in
+        //    // which case we should not throw due to timeout.
+        //    if (disconnect_cts->is_canceled())
+        //    {
+        //        if (run_callback)
+        //        {
+        //            // The callback checks the disconnect_cts token and will handle it appropriately
+        //            callback({}, nullptr);
+        //        }
+        //    }
+        //    else
+        //    {
+        //        if (run_callback)
+        //        {
+        //            callback({}, std::make_exception_ptr(signalr_exception("transport timed out when trying to connect")));
+        //        }
+        //    }
+        //}).detach();
 
         connection->send_connect_request(transport, url, [callback, connect_request_done, connect_request_lock, transport](std::exception_ptr exception)
             {

--- a/src/signalrclient/connection_impl.cpp
+++ b/src/signalrclient/connection_impl.cpp
@@ -320,19 +320,6 @@ namespace signalr
             });
     }
 
-    void timer(std::shared_ptr<scheduler> event_loop, std::function<bool(std::chrono::milliseconds)> func, std::chrono::milliseconds time)
-    {
-        event_loop->schedule([func, event_loop, time]()
-            mutable
-            {
-                time = time + std::chrono::seconds(1);
-                if (!func(time))
-                {
-                    timer(event_loop, func, time);
-                }
-            }, std::chrono::seconds(1));
-    }
-
     void connection_impl::start_transport(const std::string& url, std::function<void(std::shared_ptr<transport>, std::exception_ptr)> callback)
     {
         auto connection = shared_from_this();
@@ -462,7 +449,7 @@ namespace signalr
                 }
             }
             return true;
-        }, std::chrono::milliseconds::zero());
+        });
 
         connection->send_connect_request(transport, url, [callback, connect_request_done, connect_request_lock, transport](std::exception_ptr exception)
             {

--- a/src/signalrclient/connection_impl.cpp
+++ b/src/signalrclient/connection_impl.cpp
@@ -435,7 +435,7 @@ namespace signalr
                 // no op after connection started successfully
                 if (*connect_request_done == false)
                 {
-                    if (duration < std::chrono::seconds(5))
+                    if (!disconnect_cts->is_canceled() && duration < std::chrono::seconds(5))
                     {
                         return false;
                     }

--- a/src/signalrclient/connection_impl.h
+++ b/src/signalrclient/connection_impl.h
@@ -30,7 +30,7 @@ namespace signalr
         static std::shared_ptr<connection_impl> create(const std::string& url, trace_level trace_level, const std::shared_ptr<log_writer>& log_writer);
 
         static std::shared_ptr<connection_impl> create(const std::string& url, trace_level trace_level, const std::shared_ptr<log_writer>& log_writer,
-            std::shared_ptr<http_client> http_client, std::function<std::shared_ptr<websocket_client>(const signalr_client_config&)> websocket_factory, bool skip_negotiation = false);
+            std::function<std::shared_ptr<http_client>(const signalr_client_config&)> http_client_factory, std::function<std::shared_ptr<websocket_client>(const signalr_client_config&)> websocket_factory, bool skip_negotiation = false);
 
         connection_impl(const connection_impl&) = delete;
 
@@ -67,10 +67,10 @@ namespace signalr
         cancellation_token m_start_completed_event;
         std::string m_connection_id;
         std::string m_connection_token;
-        std::shared_ptr<http_client> m_http_client;
+        std::function<std::shared_ptr<http_client>(const signalr_client_config&)> m_http_client_factory;
 
         connection_impl(const std::string& url, trace_level trace_level, const std::shared_ptr<log_writer>& log_writer,
-            std::shared_ptr<http_client> http_client, std::function<std::shared_ptr<websocket_client>(const signalr_client_config&)> websocket_factory, bool skip_negotiation);
+            std::function<std::shared_ptr<http_client>(const signalr_client_config&)> http_client_factory, std::function<std::shared_ptr<websocket_client>(const signalr_client_config&)> websocket_factory, bool skip_negotiation);
 
         void start_transport(const std::string& url, std::function<void(std::shared_ptr<transport>, std::exception_ptr)> callback);
         void send_connect_request(const std::shared_ptr<transport>& transport,

--- a/src/signalrclient/connection_impl.h
+++ b/src/signalrclient/connection_impl.h
@@ -50,6 +50,7 @@ namespace signalr
         void set_client_config(const signalr_client_config& config);
 
     private:
+        std::shared_ptr<scheduler> m_scheduler;
         std::string m_base_url;
         std::atomic<connection_state> m_connection_state;
         logger m_logger;

--- a/src/signalrclient/connection_impl.h
+++ b/src/signalrclient/connection_impl.h
@@ -70,9 +70,6 @@ namespace signalr
         std::shared_ptr<http_client> m_http_client;
 
         connection_impl(const std::string& url, trace_level trace_level, const std::shared_ptr<log_writer>& log_writer,
-            std::unique_ptr<http_client> http_client, std::unique_ptr<transport_factory> transport_factory, bool skip_negotiation);
-
-        connection_impl(const std::string& url, trace_level trace_level, const std::shared_ptr<log_writer>& log_writer,
             std::shared_ptr<http_client> http_client, std::function<std::shared_ptr<websocket_client>(const signalr_client_config&)> websocket_factory, bool skip_negotiation);
 
         void start_transport(const std::string& url, std::function<void(std::shared_ptr<transport>, std::exception_ptr)> callback);

--- a/src/signalrclient/hub_connection.cpp
+++ b/src/signalrclient/hub_connection.cpp
@@ -11,10 +11,10 @@
 
 namespace signalr
 {
-    hub_connection::hub_connection(const std::string& url,
+    hub_connection::hub_connection(const std::string& url, std::shared_ptr<scheduler> scheduler,
         trace_level trace_level, std::shared_ptr<log_writer> log_writer, std::shared_ptr<http_client> http_client,
         std::function<std::shared_ptr<websocket_client>(const signalr_client_config&)> websocket_factory, const bool skip_negotiation)
-        : m_pImpl(hub_connection_impl::create(url, trace_level, log_writer, http_client, websocket_factory, skip_negotiation))
+        : m_pImpl(hub_connection_impl::create(url, scheduler, trace_level, log_writer, http_client, websocket_factory, skip_negotiation))
     {}
 
     hub_connection::hub_connection(hub_connection&& rhs) noexcept

--- a/src/signalrclient/hub_connection.cpp
+++ b/src/signalrclient/hub_connection.cpp
@@ -11,10 +11,10 @@
 
 namespace signalr
 {
-    hub_connection::hub_connection(const std::string& url, std::shared_ptr<scheduler> scheduler,
+    hub_connection::hub_connection(const std::string& url,
         trace_level trace_level, std::shared_ptr<log_writer> log_writer, std::shared_ptr<http_client> http_client,
         std::function<std::shared_ptr<websocket_client>(const signalr_client_config&)> websocket_factory, const bool skip_negotiation)
-        : m_pImpl(hub_connection_impl::create(url, scheduler, trace_level, log_writer, http_client, websocket_factory, skip_negotiation))
+        : m_pImpl(hub_connection_impl::create(url, trace_level, log_writer, http_client, websocket_factory, skip_negotiation))
     {}
 
     hub_connection::hub_connection(hub_connection&& rhs) noexcept

--- a/src/signalrclient/hub_connection.cpp
+++ b/src/signalrclient/hub_connection.cpp
@@ -12,9 +12,9 @@
 namespace signalr
 {
     hub_connection::hub_connection(const std::string& url,
-        trace_level trace_level, std::shared_ptr<log_writer> log_writer, std::shared_ptr<http_client> http_client,
+        trace_level trace_level, std::shared_ptr<log_writer> log_writer, std::function<std::shared_ptr<http_client>(const signalr_client_config&)> http_client_factory,
         std::function<std::shared_ptr<websocket_client>(const signalr_client_config&)> websocket_factory, const bool skip_negotiation)
-        : m_pImpl(hub_connection_impl::create(url, trace_level, log_writer, http_client, websocket_factory, skip_negotiation))
+        : m_pImpl(hub_connection_impl::create(url, trace_level, log_writer, http_client_factory, websocket_factory, skip_negotiation))
     {}
 
     hub_connection::hub_connection(hub_connection&& rhs) noexcept

--- a/src/signalrclient/hub_connection_builder.cpp
+++ b/src/signalrclient/hub_connection_builder.cpp
@@ -5,7 +5,6 @@
 #include "stdafx.h"
 #include "signalrclient/hub_connection_builder.h"
 #include <stdexcept>
-#include "signalr_default_scheduler.h"
 
 namespace signalr
 {

--- a/src/signalrclient/hub_connection_builder.cpp
+++ b/src/signalrclient/hub_connection_builder.cpp
@@ -5,6 +5,7 @@
 #include "stdafx.h"
 #include "signalrclient/hub_connection_builder.h"
 #include <stdexcept>
+#include "signalr_default_scheduler.h"
 
 namespace signalr
 {
@@ -92,6 +93,6 @@ namespace signalr
         }
 #endif
 
-        return hub_connection(m_url, m_log_level, m_logger, m_http_client, m_websocket_factory, m_skip_negotiation);
+        return hub_connection(m_url, std::make_shared<signalr_default_scheduler>(), m_log_level, m_logger, m_http_client, m_websocket_factory, m_skip_negotiation);
     }
 }

--- a/src/signalrclient/hub_connection_builder.cpp
+++ b/src/signalrclient/hub_connection_builder.cpp
@@ -93,6 +93,6 @@ namespace signalr
         }
 #endif
 
-        return hub_connection(m_url, std::make_shared<signalr_default_scheduler>(), m_log_level, m_logger, m_http_client, m_websocket_factory, m_skip_negotiation);
+        return hub_connection(m_url, m_log_level, m_logger, m_http_client, m_websocket_factory, m_skip_negotiation);
     }
 }

--- a/src/signalrclient/hub_connection_builder.cpp
+++ b/src/signalrclient/hub_connection_builder.cpp
@@ -64,9 +64,9 @@ namespace signalr
         return *this;
     }
 
-    hub_connection_builder& hub_connection_builder::with_http_client(std::shared_ptr<http_client> http_client)
+    hub_connection_builder& hub_connection_builder::with_http_client_factory(std::function<std::shared_ptr<http_client>(const signalr_client_config&)> http_client_factory)
     {
-        m_http_client = http_client;
+        m_http_client_factory = http_client_factory;
 
         return *this;
     }
@@ -81,9 +81,9 @@ namespace signalr
     hub_connection hub_connection_builder::build()
     {
 #ifndef USE_CPPRESTSDK
-        if (m_http_client == nullptr)
+        if (m_http_client_factory == nullptr)
         {
-            throw std::runtime_error("An http client must be provided using 'with_http_client' on the builder.");
+            throw std::runtime_error("An http client must be provided using 'with_http_client_factory' on the builder.");
         }
 
         if (m_websocket_factory == nullptr)
@@ -92,6 +92,6 @@ namespace signalr
         }
 #endif
 
-        return hub_connection(m_url, m_log_level, m_logger, m_http_client, m_websocket_factory, m_skip_negotiation);
+        return hub_connection(m_url, m_log_level, m_logger, m_http_client_factory, m_websocket_factory, m_skip_negotiation);
     }
 }

--- a/src/signalrclient/hub_connection_impl.cpp
+++ b/src/signalrclient/hub_connection_impl.cpp
@@ -22,11 +22,11 @@ namespace signalr
             const std::function<void(const std::exception_ptr e)>& set_exception);
     }
 
-    std::shared_ptr<hub_connection_impl> hub_connection_impl::create(const std::string& url,
+    std::shared_ptr<hub_connection_impl> hub_connection_impl::create(const std::string& url, std::shared_ptr<scheduler> scheduler,
         trace_level trace_level, const std::shared_ptr<log_writer>& log_writer, std::shared_ptr<http_client> http_client,
         std::function<std::shared_ptr<websocket_client>(const signalr_client_config&)> websocket_factory, const bool skip_negotiation)
     {
-        auto connection = std::shared_ptr<hub_connection_impl>(new hub_connection_impl(url,
+        auto connection = std::shared_ptr<hub_connection_impl>(new hub_connection_impl(url, scheduler,
             trace_level, log_writer, http_client, websocket_factory, skip_negotiation));
 
         connection->initialize();
@@ -34,10 +34,10 @@ namespace signalr
         return connection;
     }
 
-    hub_connection_impl::hub_connection_impl(const std::string& url, trace_level trace_level,
+    hub_connection_impl::hub_connection_impl(const std::string& url, std::shared_ptr<scheduler> scheduler, trace_level trace_level,
         const std::shared_ptr<log_writer>& log_writer, std::shared_ptr<http_client> http_client,
         std::function<std::shared_ptr<websocket_client>(const signalr_client_config&)> websocket_factory, const bool skip_negotiation)
-        : m_connection(connection_impl::create(url, trace_level, log_writer,
+        : m_connection(connection_impl::create(url, scheduler, trace_level, log_writer,
             http_client, websocket_factory, skip_negotiation)), m_logger(log_writer, trace_level),
         m_callback_manager("connection went out of scope before invocation result was received"),
         m_handshakeReceived(false), m_disconnected([]() noexcept {}), m_protocol(std::unique_ptr<json_hub_protocol>(new json_hub_protocol()))

--- a/src/signalrclient/hub_connection_impl.cpp
+++ b/src/signalrclient/hub_connection_impl.cpp
@@ -34,10 +34,10 @@ namespace signalr
         return connection;
     }
 
-    hub_connection_impl::hub_connection_impl(const std::string& url, std::shared_ptr<scheduler> scheduler, trace_level trace_level,
+    hub_connection_impl::hub_connection_impl(const std::string& url, trace_level trace_level,
         const std::shared_ptr<log_writer>& log_writer, std::shared_ptr<http_client> http_client,
         std::function<std::shared_ptr<websocket_client>(const signalr_client_config&)> websocket_factory, const bool skip_negotiation)
-        : m_connection(connection_impl::create(url, scheduler, trace_level, log_writer,
+        : m_connection(connection_impl::create(url, trace_level, log_writer,
             http_client, websocket_factory, skip_negotiation)), m_logger(log_writer, trace_level),
         m_callback_manager("connection went out of scope before invocation result was received"),
         m_handshakeReceived(false), m_disconnected([]() noexcept {}), m_protocol(std::unique_ptr<json_hub_protocol>(new json_hub_protocol()))

--- a/src/signalrclient/hub_connection_impl.cpp
+++ b/src/signalrclient/hub_connection_impl.cpp
@@ -22,11 +22,11 @@ namespace signalr
             const std::function<void(const std::exception_ptr e)>& set_exception);
     }
 
-    std::shared_ptr<hub_connection_impl> hub_connection_impl::create(const std::string& url, std::shared_ptr<scheduler> scheduler,
+    std::shared_ptr<hub_connection_impl> hub_connection_impl::create(const std::string& url,
         trace_level trace_level, const std::shared_ptr<log_writer>& log_writer, std::shared_ptr<http_client> http_client,
         std::function<std::shared_ptr<websocket_client>(const signalr_client_config&)> websocket_factory, const bool skip_negotiation)
     {
-        auto connection = std::shared_ptr<hub_connection_impl>(new hub_connection_impl(url, scheduler,
+        auto connection = std::shared_ptr<hub_connection_impl>(new hub_connection_impl(url,
             trace_level, log_writer, http_client, websocket_factory, skip_negotiation));
 
         connection->initialize();

--- a/src/signalrclient/hub_connection_impl.cpp
+++ b/src/signalrclient/hub_connection_impl.cpp
@@ -23,11 +23,11 @@ namespace signalr
     }
 
     std::shared_ptr<hub_connection_impl> hub_connection_impl::create(const std::string& url,
-        trace_level trace_level, const std::shared_ptr<log_writer>& log_writer, std::shared_ptr<http_client> http_client,
+        trace_level trace_level, const std::shared_ptr<log_writer>& log_writer, std::function<std::shared_ptr<http_client>(const signalr_client_config&)> http_client_factory,
         std::function<std::shared_ptr<websocket_client>(const signalr_client_config&)> websocket_factory, const bool skip_negotiation)
     {
         auto connection = std::shared_ptr<hub_connection_impl>(new hub_connection_impl(url,
-            trace_level, log_writer, http_client, websocket_factory, skip_negotiation));
+            trace_level, log_writer, http_client_factory, websocket_factory, skip_negotiation));
 
         connection->initialize();
 
@@ -35,10 +35,10 @@ namespace signalr
     }
 
     hub_connection_impl::hub_connection_impl(const std::string& url, trace_level trace_level,
-        const std::shared_ptr<log_writer>& log_writer, std::shared_ptr<http_client> http_client,
+        const std::shared_ptr<log_writer>& log_writer, std::function<std::shared_ptr<http_client>(const signalr_client_config&)> http_client_factory,
         std::function<std::shared_ptr<websocket_client>(const signalr_client_config&)> websocket_factory, const bool skip_negotiation)
         : m_connection(connection_impl::create(url, trace_level, log_writer,
-            http_client, websocket_factory, skip_negotiation)), m_logger(log_writer, trace_level),
+            http_client_factory, websocket_factory, skip_negotiation)), m_logger(log_writer, trace_level),
         m_callback_manager("connection went out of scope before invocation result was received"),
         m_handshakeReceived(false), m_disconnected([]() noexcept {}), m_protocol(std::unique_ptr<json_hub_protocol>(new json_hub_protocol()))
     {}

--- a/src/signalrclient/hub_connection_impl.h
+++ b/src/signalrclient/hub_connection_impl.h
@@ -24,7 +24,7 @@ namespace signalr
     class hub_connection_impl : public std::enable_shared_from_this<hub_connection_impl>
     {
     public:
-        static std::shared_ptr<hub_connection_impl> create(const std::string& url,
+        static std::shared_ptr<hub_connection_impl> create(const std::string& url, std::shared_ptr<scheduler> scheduler,
             trace_level trace_level, const std::shared_ptr<log_writer>& log_writer, std::shared_ptr<http_client> http_client,
             std::function<std::shared_ptr<websocket_client>(const signalr_client_config&)> websocket_factory, bool skip_negotiation = false);
 
@@ -46,7 +46,7 @@ namespace signalr
         void set_disconnected(const std::function<void()>& disconnected);
 
     private:
-        hub_connection_impl(const std::string& url, trace_level trace_level,
+        hub_connection_impl(const std::string& url, std::shared_ptr<scheduler> scheduler, trace_level trace_level,
             const std::shared_ptr<log_writer>& log_writer, std::shared_ptr<http_client> http_client,
             std::function<std::shared_ptr<websocket_client>(const signalr_client_config&)> websocket_factory,
             bool skip_negotiation);

--- a/src/signalrclient/hub_connection_impl.h
+++ b/src/signalrclient/hub_connection_impl.h
@@ -46,7 +46,7 @@ namespace signalr
         void set_disconnected(const std::function<void()>& disconnected);
 
     private:
-        hub_connection_impl(const std::string& url, std::shared_ptr<scheduler> scheduler, trace_level trace_level,
+        hub_connection_impl(const std::string& url, trace_level trace_level,
             const std::shared_ptr<log_writer>& log_writer, std::shared_ptr<http_client> http_client,
             std::function<std::shared_ptr<websocket_client>(const signalr_client_config&)> websocket_factory,
             bool skip_negotiation);

--- a/src/signalrclient/hub_connection_impl.h
+++ b/src/signalrclient/hub_connection_impl.h
@@ -24,7 +24,7 @@ namespace signalr
     class hub_connection_impl : public std::enable_shared_from_this<hub_connection_impl>
     {
     public:
-        static std::shared_ptr<hub_connection_impl> create(const std::string& url, std::shared_ptr<scheduler> scheduler,
+        static std::shared_ptr<hub_connection_impl> create(const std::string& url,
             trace_level trace_level, const std::shared_ptr<log_writer>& log_writer, std::shared_ptr<http_client> http_client,
             std::function<std::shared_ptr<websocket_client>(const signalr_client_config&)> websocket_factory, bool skip_negotiation = false);
 

--- a/src/signalrclient/hub_connection_impl.h
+++ b/src/signalrclient/hub_connection_impl.h
@@ -25,7 +25,7 @@ namespace signalr
     {
     public:
         static std::shared_ptr<hub_connection_impl> create(const std::string& url,
-            trace_level trace_level, const std::shared_ptr<log_writer>& log_writer, std::shared_ptr<http_client> http_client,
+            trace_level trace_level, const std::shared_ptr<log_writer>& log_writer, std::function<std::shared_ptr<http_client>(const signalr_client_config&)> http_client_factory,
             std::function<std::shared_ptr<websocket_client>(const signalr_client_config&)> websocket_factory, bool skip_negotiation = false);
 
         hub_connection_impl(const hub_connection_impl&) = delete;
@@ -47,7 +47,7 @@ namespace signalr
 
     private:
         hub_connection_impl(const std::string& url, trace_level trace_level,
-            const std::shared_ptr<log_writer>& log_writer, std::shared_ptr<http_client> http_client,
+            const std::shared_ptr<log_writer>& log_writer, std::function<std::shared_ptr<http_client>(const signalr_client_config&)> http_client_factory,
             std::function<std::shared_ptr<websocket_client>(const signalr_client_config&)> websocket_factory,
             bool skip_negotiation);
 

--- a/src/signalrclient/negotiate.cpp
+++ b/src/signalrclient/negotiate.cpp
@@ -14,7 +14,7 @@ namespace signalr
     {
         const int negotiate_version = 1;
 
-        void negotiate(std::shared_ptr<http_client>& client, const std::string& base_url,
+        void negotiate(std::shared_ptr<http_client> client, const std::string& base_url,
             const signalr_client_config& config,
             std::function<void(negotiation_response&&, std::exception_ptr)> callback) noexcept
         {

--- a/src/signalrclient/negotiate.cpp
+++ b/src/signalrclient/negotiate.cpp
@@ -14,7 +14,7 @@ namespace signalr
     {
         const int negotiate_version = 1;
 
-        void negotiate(std::shared_ptr<http_client> client, const std::string& base_url,
+        void negotiate(std::shared_ptr<http_client>& client, const std::string& base_url,
             const signalr_client_config& config,
             std::function<void(negotiation_response&&, std::exception_ptr)> callback) noexcept
         {

--- a/src/signalrclient/negotiate.cpp
+++ b/src/signalrclient/negotiate.cpp
@@ -14,7 +14,7 @@ namespace signalr
     {
         const int negotiate_version = 1;
 
-        void negotiate(http_client& client, const std::string& base_url,
+        void negotiate(std::shared_ptr<http_client> client, const std::string& base_url,
             const signalr_client_config& config,
             std::function<void(negotiation_response&&, std::exception_ptr)> callback) noexcept
         {
@@ -38,7 +38,7 @@ namespace signalr
             request.timeout = config.get_http_client_config().timeout();
 #endif
 
-            client.send(negotiate_url, request, [callback](const http_response& http_response, std::exception_ptr exception)
+            client->send(negotiate_url, request, [callback](const http_response& http_response, std::exception_ptr exception)
             {
                 if (exception != nullptr)
                 {

--- a/src/signalrclient/negotiate.h
+++ b/src/signalrclient/negotiate.h
@@ -12,7 +12,7 @@ namespace signalr
 {
     namespace negotiate
     {
-        void negotiate(std::shared_ptr<http_client>& client, const std::string& base_url,
+        void negotiate(std::shared_ptr<http_client> client, const std::string& base_url,
             const signalr_client_config& signalr_client_config,
             std::function<void(negotiation_response&&, std::exception_ptr)> callback) noexcept;
     }

--- a/src/signalrclient/negotiate.h
+++ b/src/signalrclient/negotiate.h
@@ -12,7 +12,7 @@ namespace signalr
 {
     namespace negotiate
     {
-        void negotiate(http_client& client, const std::string& base_url,
+        void negotiate(std::shared_ptr<http_client> client, const std::string& base_url,
             const signalr_client_config& signalr_client_config,
             std::function<void(negotiation_response&&, std::exception_ptr)> callback) noexcept;
     }

--- a/src/signalrclient/negotiate.h
+++ b/src/signalrclient/negotiate.h
@@ -12,7 +12,7 @@ namespace signalr
 {
     namespace negotiate
     {
-        void negotiate(std::shared_ptr<http_client> client, const std::string& base_url,
+        void negotiate(std::shared_ptr<http_client>& client, const std::string& base_url,
             const signalr_client_config& signalr_client_config,
             std::function<void(negotiation_response&&, std::exception_ptr)> callback) noexcept;
     }

--- a/src/signalrclient/signalr_client_config.cpp
+++ b/src/signalrclient/signalr_client_config.cpp
@@ -4,6 +4,7 @@
 
 #include "stdafx.h"
 #include "signalrclient/signalr_client_config.h"
+#include "signalr_default_scheduler.h"
 
 namespace signalr
 {
@@ -40,6 +41,11 @@ namespace signalr
         m_websocket_client_config = websocket_client_config;
     }
 #endif
+
+    signalr_client_config::signalr_client_config()
+    {
+        m_scheduler = std::make_shared<signalr_default_scheduler>();
+    }
 
     const std::map<std::string, std::string>& signalr_client_config::get_http_headers() const noexcept
     {

--- a/src/signalrclient/signalr_client_config.cpp
+++ b/src/signalrclient/signalr_client_config.cpp
@@ -55,4 +55,14 @@ namespace signalr
     {
         m_http_headers = http_headers;
     }
+
+    void signalr_client_config::set_scheduler(std::shared_ptr<scheduler> scheduler)
+    {
+        m_scheduler = scheduler;
+    }
+
+    std::shared_ptr<scheduler> signalr_client_config::get_scheduler() const noexcept
+    {
+        return m_scheduler;
+    }
 }

--- a/src/signalrclient/signalr_client_config.cpp
+++ b/src/signalrclient/signalr_client_config.cpp
@@ -64,6 +64,11 @@ namespace signalr
 
     void signalr_client_config::set_scheduler(std::shared_ptr<scheduler> scheduler)
     {
+        if (!scheduler)
+        {
+            return;
+        }
+
         m_scheduler = std::move(scheduler);
     }
 

--- a/src/signalrclient/signalr_client_config.cpp
+++ b/src/signalrclient/signalr_client_config.cpp
@@ -64,10 +64,10 @@ namespace signalr
 
     void signalr_client_config::set_scheduler(std::shared_ptr<scheduler> scheduler)
     {
-        m_scheduler = scheduler;
+        m_scheduler = std::move(scheduler);
     }
 
-    std::shared_ptr<scheduler> signalr_client_config::get_scheduler() const noexcept
+    const std::shared_ptr<scheduler>& signalr_client_config::get_scheduler() const noexcept
     {
         return m_scheduler;
     }

--- a/src/signalrclient/signalr_default_scheduler.cpp
+++ b/src/signalrclient/signalr_default_scheduler.cpp
@@ -66,14 +66,18 @@ namespace signalr
 
                     for (auto& cb : tmp)
                     {
-                        try
-                        {
-                            cb.first();
-                        }
-                        catch (...)
-                        {
-                            // ignore exceptions?
-                        }
+                        // todo: dispatch to threadpool
+                        std::thread([cb]()
+                            {
+                                try
+                                {
+                                    cb.first();
+                                }
+                                catch (...)
+                                {
+                                    // ignore exceptions?
+                                }
+                            }).detach();
                     }
 
                     tmp.clear();

--- a/src/signalrclient/signalr_default_scheduler.cpp
+++ b/src/signalrclient/signalr_default_scheduler.cpp
@@ -1,0 +1,139 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include "stdafx.h"
+#include "signalr_default_scheduler.h"
+
+namespace signalr
+{
+    void signalr_default_scheduler::schedule(const signalr_cb& cb, std::chrono::milliseconds delay)
+    {
+        schedule([cb]() { cb(nullptr); }, delay);
+    }
+
+    void signalr_default_scheduler::schedule(const signalr_cb& cb, std::exception_ptr exception, std::chrono::milliseconds delay)
+    {
+        schedule([cb, exception]() { cb(exception); }, delay);
+    }
+
+    void signalr_default_scheduler::schedule(const signalr_message_cb& cb, std::string message, std::chrono::milliseconds delay)
+    {
+        schedule([cb, message]() { cb(message, nullptr); }, delay);
+    }
+
+    void signalr_default_scheduler::schedule(const signalr_message_cb& cb, std::exception_ptr exception, std::chrono::milliseconds delay)
+    {
+        schedule([cb, exception]() { cb("", exception); }, delay);
+    }
+
+    void signalr_default_scheduler::schedule(const signalr_base_cb& cb, std::chrono::milliseconds delay)
+    {
+        if (delay.count() == 0)
+        {
+            {
+                std::lock_guard<std::mutex> lock((*m_callback_lock));
+                m_callbacks->push_back(std::make_pair(cb, delay));
+            } // unlock
+            m_callback_cv->notify_one();
+        }
+        else
+        {
+            {
+                std::lock_guard<std::mutex> lock((*m_timer_lock));
+                m_timer_callbacks->push_back(std::make_pair(cb, delay));
+            } // unlock
+            m_timer_cv->notify_one();
+        }
+    }
+
+    void signalr_default_scheduler::run()
+    {
+        auto closed = m_closed;
+        auto callbacks = m_callbacks;
+        auto callback_lock = m_callback_lock;
+        auto cv = m_callback_cv;
+        std::thread([callbacks, callback_lock, cv, closed]()
+            {
+                std::vector<std::pair<signalr_base_cb, std::chrono::milliseconds>> tmp;
+                while ((*closed) == false)
+                {
+                    {
+                        std::unique_lock<std::mutex> lock((*callback_lock));
+                        cv->wait(lock, [&callbacks, &closed] { return (*closed) || !callbacks->empty(); });
+                        tmp.swap((*callbacks)); // take all the callbacks while under the lock
+                    } // unlock
+
+                    for (auto& cb : tmp)
+                    {
+                        try
+                        {
+                            cb.first();
+                        }
+                        catch (...)
+                        {
+                            // ignore exceptions?
+                        }
+                    }
+
+                    tmp.clear();
+                }
+            }).detach();
+
+            callbacks = m_timer_callbacks;
+            callback_lock = m_timer_lock;
+            cv = m_timer_cv;
+        std::thread([callbacks, callback_lock, cv, closed]()
+            {
+                std::vector<std::pair<signalr_base_cb, std::chrono::milliseconds>> tmp;
+                while ((*closed) == false)
+                {
+                    {
+                        std::unique_lock<std::mutex> lock((*callback_lock));
+                        cv->wait_for(lock, std::chrono::milliseconds(15), [&closed] { return (*closed); });
+                        auto it = callbacks->begin();
+                        while (it != callbacks->end())
+                        {
+                            // todo: calculate delay
+                            (*it).second -= std::chrono::milliseconds(15);
+                            if ((*it).second <= std::chrono::milliseconds::zero())
+                            {
+                                tmp.push_back((*it));
+                                it = callbacks->erase(it);
+                            }
+                            else
+                            {
+                                ++it;
+                            }
+                        }
+                    } // unlock
+
+                    for (auto& cb : tmp)
+                    {
+                        try
+                        {
+                            cb.first();
+                        }
+                        catch (...)
+                        {
+                            // ignore exceptions?
+                        }
+                    }
+
+                    tmp.clear();
+                }
+            }).detach();
+    }
+
+    void signalr_default_scheduler::close()
+    {
+        (*m_closed) = true;
+        m_callback_cv->notify_one();
+        m_timer_cv->notify_one();
+    }
+
+    signalr_default_scheduler::~signalr_default_scheduler()
+    {
+        close();
+    }
+}

--- a/src/signalrclient/signalr_default_scheduler.cpp
+++ b/src/signalrclient/signalr_default_scheduler.cpp
@@ -4,6 +4,7 @@
 
 #include "stdafx.h"
 #include "signalr_default_scheduler.h"
+#include <thread>
 
 namespace signalr
 {

--- a/src/signalrclient/signalr_default_scheduler.cpp
+++ b/src/signalrclient/signalr_default_scheduler.cpp
@@ -14,7 +14,7 @@ namespace signalr
     {
         auto internals = m_internals;
 
-        std::thread([=]()
+        m_thread = std::thread([=]()
             {
                 while (true)
                 {
@@ -50,7 +50,7 @@ namespace signalr
                 }
 
                 assert(internals->m_callbacks.empty());
-            }).detach();
+            });
     }
 
     void thread::add(signalr_base_cb cb)
@@ -68,6 +68,7 @@ namespace signalr
     {
         m_internals->m_closed = true;
         m_internals->m_callback_cv.notify_one();
+        m_thread.join();
     }
 
     bool thread::is_free() const

--- a/src/signalrclient/signalr_default_scheduler.cpp
+++ b/src/signalrclient/signalr_default_scheduler.cpp
@@ -80,26 +80,6 @@ namespace signalr
         shutdown();
     }
 
-    void signalr_default_scheduler::schedule(const signalr_cb& cb, std::chrono::milliseconds delay)
-    {
-        schedule([cb]() { cb(nullptr); }, delay);
-    }
-
-    void signalr_default_scheduler::schedule(const signalr_cb& cb, std::exception_ptr exception, std::chrono::milliseconds delay)
-    {
-        schedule([cb, exception]() { cb(exception); }, delay);
-    }
-
-    void signalr_default_scheduler::schedule(const signalr_message_cb& cb, std::string message, std::chrono::milliseconds delay)
-    {
-        schedule([cb, message]() { cb(message, nullptr); }, delay);
-    }
-
-    void signalr_default_scheduler::schedule(const signalr_message_cb& cb, std::exception_ptr exception, std::chrono::milliseconds delay)
-    {
-        schedule([cb, exception]() { cb("", exception); }, delay);
-    }
-
     void signalr_default_scheduler::schedule(const signalr_base_cb& cb, std::chrono::milliseconds delay)
     {
         {

--- a/src/signalrclient/signalr_default_scheduler.cpp
+++ b/src/signalrclient/signalr_default_scheduler.cpp
@@ -27,7 +27,6 @@ namespace signalr
 
                             if (closed && callback == nullptr)
                             {
-                                assert(callback == nullptr);
                                 return;
                             }
 
@@ -136,7 +135,6 @@ namespace signalr
 
                     if (closed && callbacks.empty())
                     {
-                        assert(callbacks.empty());
                         return;
                     }
 

--- a/src/signalrclient/signalr_default_scheduler.h
+++ b/src/signalrclient/signalr_default_scheduler.h
@@ -1,0 +1,42 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#pragma once
+
+#include "../include/signalrclient/scheduler.h"
+
+namespace signalr
+{
+    struct signalr_default_scheduler : scheduler
+    {
+        signalr_default_scheduler() : m_callbacks(std::make_shared<std::vector<std::pair<signalr_base_cb, std::chrono::milliseconds>>>()),
+            m_timer_callbacks(std::make_shared<std::vector<std::pair<signalr_base_cb, std::chrono::milliseconds>>>()), m_callback_lock(std::make_shared<std::mutex>()),
+            m_timer_lock(std::make_shared<std::mutex>()), m_callback_cv(std::make_shared<std::condition_variable>()), m_timer_cv(std::make_shared<std::condition_variable>()),
+            m_closed(std::make_shared<bool>())
+        {
+            run();
+        }
+        signalr_default_scheduler(const signalr_default_scheduler&) = delete;
+        signalr_default_scheduler& operator=(const signalr_default_scheduler&) = delete;
+
+        void schedule(const signalr_cb& cb, std::chrono::milliseconds delay = std::chrono::milliseconds::zero());
+        void schedule(const signalr_cb& cb, std::exception_ptr, std::chrono::milliseconds delay = std::chrono::milliseconds::zero());
+        void schedule(const signalr_message_cb& cb, std::string, std::chrono::milliseconds delay = std::chrono::milliseconds::zero());
+        void schedule(const signalr_message_cb& cb, std::exception_ptr, std::chrono::milliseconds delay = std::chrono::milliseconds::zero());
+        void schedule(const signalr_base_cb& cb, std::chrono::milliseconds delay = std::chrono::milliseconds::zero());
+        ~signalr_default_scheduler();
+
+    private:
+        void run();
+        std::shared_ptr<std::vector<std::pair<signalr_base_cb, std::chrono::milliseconds>>> m_callbacks;
+        std::shared_ptr<std::vector<std::pair<signalr_base_cb, std::chrono::milliseconds>>> m_timer_callbacks;
+        std::shared_ptr<std::mutex> m_callback_lock;
+        std::shared_ptr<std::mutex> m_timer_lock;
+        std::shared_ptr<std::condition_variable> m_callback_cv;
+        std::shared_ptr<std::condition_variable> m_timer_cv;
+        std::shared_ptr<bool> m_closed;
+
+        void close();
+    };
+}

--- a/src/signalrclient/signalr_default_scheduler.h
+++ b/src/signalrclient/signalr_default_scheduler.h
@@ -8,12 +8,26 @@
 
 namespace signalr
 {
+    struct thread
+    {
+    public:
+        thread();
+        void add(std::pair<signalr_base_cb, std::chrono::time_point<std::chrono::steady_clock, std::chrono::nanoseconds>>);
+        bool is_free() const;
+        void shutdown();
+        ~thread();
+    private:
+        std::shared_ptr<std::vector<std::pair<signalr_base_cb, std::chrono::time_point<std::chrono::steady_clock, std::chrono::nanoseconds>>>> m_callbacks;
+        std::shared_ptr<std::mutex> m_callback_lock;
+        std::shared_ptr<std::condition_variable> m_callback_cv;
+        std::shared_ptr<bool> m_closed;
+        std::shared_ptr<bool> m_busy;
+    };
+
     struct signalr_default_scheduler : scheduler
     {
-        signalr_default_scheduler() : m_callbacks(std::make_shared<std::vector<std::pair<signalr_base_cb, std::chrono::nanoseconds>>>()),
-            m_timer_callbacks(std::make_shared<std::vector<std::pair<signalr_base_cb, std::chrono::nanoseconds>>>()), m_callback_lock(std::make_shared<std::mutex>()),
-            m_timer_lock(std::make_shared<std::mutex>()), m_callback_cv(std::make_shared<std::condition_variable>()), m_timer_cv(std::make_shared<std::condition_variable>()),
-            m_closed(std::make_shared<bool>())
+        signalr_default_scheduler() : m_callbacks(std::make_shared<std::vector<std::pair<signalr_base_cb, std::chrono::time_point<std::chrono::steady_clock, std::chrono::nanoseconds>>>>()),
+            m_callback_lock(std::make_shared<std::mutex>()), m_callback_cv(std::make_shared<std::condition_variable>()), m_closed(std::make_shared<bool>())
         {
             run();
         }
@@ -29,12 +43,9 @@ namespace signalr
 
     private:
         void run();
-        std::shared_ptr<std::vector<std::pair<signalr_base_cb, std::chrono::nanoseconds>>> m_callbacks;
-        std::shared_ptr<std::vector<std::pair<signalr_base_cb, std::chrono::nanoseconds>>> m_timer_callbacks;
+        std::shared_ptr<std::vector<std::pair<signalr_base_cb, std::chrono::time_point<std::chrono::steady_clock, std::chrono::nanoseconds>>>> m_callbacks;
         std::shared_ptr<std::mutex> m_callback_lock;
-        std::shared_ptr<std::mutex> m_timer_lock;
         std::shared_ptr<std::condition_variable> m_callback_cv;
-        std::shared_ptr<std::condition_variable> m_timer_cv;
         std::shared_ptr<bool> m_closed;
 
         void close();

--- a/src/signalrclient/signalr_default_scheduler.h
+++ b/src/signalrclient/signalr_default_scheduler.h
@@ -10,8 +10,8 @@ namespace signalr
 {
     struct signalr_default_scheduler : scheduler
     {
-        signalr_default_scheduler() : m_callbacks(std::make_shared<std::vector<std::pair<signalr_base_cb, std::chrono::milliseconds>>>()),
-            m_timer_callbacks(std::make_shared<std::vector<std::pair<signalr_base_cb, std::chrono::milliseconds>>>()), m_callback_lock(std::make_shared<std::mutex>()),
+        signalr_default_scheduler() : m_callbacks(std::make_shared<std::vector<std::pair<signalr_base_cb, std::chrono::nanoseconds>>>()),
+            m_timer_callbacks(std::make_shared<std::vector<std::pair<signalr_base_cb, std::chrono::nanoseconds>>>()), m_callback_lock(std::make_shared<std::mutex>()),
             m_timer_lock(std::make_shared<std::mutex>()), m_callback_cv(std::make_shared<std::condition_variable>()), m_timer_cv(std::make_shared<std::condition_variable>()),
             m_closed(std::make_shared<bool>())
         {
@@ -29,8 +29,8 @@ namespace signalr
 
     private:
         void run();
-        std::shared_ptr<std::vector<std::pair<signalr_base_cb, std::chrono::milliseconds>>> m_callbacks;
-        std::shared_ptr<std::vector<std::pair<signalr_base_cb, std::chrono::milliseconds>>> m_timer_callbacks;
+        std::shared_ptr<std::vector<std::pair<signalr_base_cb, std::chrono::nanoseconds>>> m_callbacks;
+        std::shared_ptr<std::vector<std::pair<signalr_base_cb, std::chrono::nanoseconds>>> m_timer_callbacks;
         std::shared_ptr<std::mutex> m_callback_lock;
         std::shared_ptr<std::mutex> m_timer_lock;
         std::shared_ptr<std::condition_variable> m_callback_cv;

--- a/src/signalrclient/signalr_default_scheduler.h
+++ b/src/signalrclient/signalr_default_scheduler.h
@@ -25,7 +25,7 @@ namespace signalr
 #pragma warning( disable: 4625 5026 4626 5027 )
         struct internals
         {
-            std::vector<signalr_base_cb> m_callbacks;
+            signalr_base_cb m_callback;
             std::mutex m_callback_lock;
             std::condition_variable m_callback_cv;
             bool m_closed;
@@ -71,4 +71,7 @@ namespace signalr
         void close();
     };
 #pragma warning( pop )
+
+    void timer_internal(const std::shared_ptr<scheduler>& scheduler, std::function<bool(std::chrono::milliseconds)> func, std::chrono::milliseconds time);
+    void timer(const std::shared_ptr<scheduler>& scheduler, std::function<bool(std::chrono::milliseconds)> func);
 }

--- a/src/signalrclient/signalr_default_scheduler.h
+++ b/src/signalrclient/signalr_default_scheduler.h
@@ -32,6 +32,9 @@ namespace signalr
         std::shared_ptr<internals> m_internals;
     };
 
+#pragma warning( push )
+    // not all virtual functions of the base class are overridden
+#pragma warning( disable : 4266 )
     struct signalr_default_scheduler : scheduler
     {
         signalr_default_scheduler() : m_internals(std::make_shared<internals>())
@@ -41,10 +44,6 @@ namespace signalr
         signalr_default_scheduler(const signalr_default_scheduler&) = delete;
         signalr_default_scheduler& operator=(const signalr_default_scheduler&) = delete;
 
-        void schedule(const signalr_cb& cb, std::chrono::milliseconds delay = std::chrono::milliseconds::zero());
-        void schedule(const signalr_cb& cb, std::exception_ptr, std::chrono::milliseconds delay = std::chrono::milliseconds::zero());
-        void schedule(const signalr_message_cb& cb, std::string, std::chrono::milliseconds delay = std::chrono::milliseconds::zero());
-        void schedule(const signalr_message_cb& cb, std::exception_ptr, std::chrono::milliseconds delay = std::chrono::milliseconds::zero());
         void schedule(const signalr_base_cb& cb, std::chrono::milliseconds delay = std::chrono::milliseconds::zero());
         ~signalr_default_scheduler();
 
@@ -66,4 +65,5 @@ namespace signalr
 
         void close();
     };
+#pragma warning( pop )
 }

--- a/src/signalrclient/signalr_default_scheduler.h
+++ b/src/signalrclient/signalr_default_scheduler.h
@@ -8,6 +8,7 @@
 #include <thread>
 #include <mutex>
 #include <vector>
+#include <condition_variable>
 
 namespace signalr
 {

--- a/src/signalrclient/signalr_default_scheduler.h
+++ b/src/signalrclient/signalr_default_scheduler.h
@@ -6,6 +6,8 @@
 
 #include "../include/signalrclient/scheduler.h"
 #include <thread>
+#include <mutex>
+#include <vector>
 
 namespace signalr
 {
@@ -72,6 +74,6 @@ namespace signalr
     };
 #pragma warning( pop )
 
-    void timer_internal(const std::shared_ptr<scheduler>& scheduler, std::function<bool(std::chrono::milliseconds)> func, std::chrono::milliseconds time);
+    void timer_internal(const std::shared_ptr<scheduler>& scheduler, std::function<bool(std::chrono::milliseconds)> func, std::chrono::milliseconds duration);
     void timer(const std::shared_ptr<scheduler>& scheduler, std::function<bool(std::chrono::milliseconds)> func);
 }

--- a/src/signalrclient/signalr_default_scheduler.h
+++ b/src/signalrclient/signalr_default_scheduler.h
@@ -17,17 +17,24 @@ namespace signalr
         void shutdown();
         ~thread();
     private:
-        std::shared_ptr<std::vector<std::pair<signalr_base_cb, std::chrono::time_point<std::chrono::steady_clock, std::chrono::nanoseconds>>>> m_callbacks;
-        std::shared_ptr<std::mutex> m_callback_lock;
-        std::shared_ptr<std::condition_variable> m_callback_cv;
-        std::shared_ptr<bool> m_closed;
-        std::shared_ptr<bool> m_busy;
+#pragma warning( push )
+#pragma warning( disable: 4625 5026 4626 5027 )
+        struct internals
+        {
+            std::vector<std::pair<signalr_base_cb, std::chrono::time_point<std::chrono::steady_clock, std::chrono::nanoseconds>>> m_callbacks;
+            std::mutex m_callback_lock;
+            std::condition_variable m_callback_cv;
+            bool m_closed;
+            bool m_busy;
+        };
+#pragma warning( pop )
+
+        std::shared_ptr<internals> m_internals;
     };
 
     struct signalr_default_scheduler : scheduler
     {
-        signalr_default_scheduler() : m_callbacks(std::make_shared<std::vector<std::pair<signalr_base_cb, std::chrono::time_point<std::chrono::steady_clock, std::chrono::nanoseconds>>>>()),
-            m_callback_lock(std::make_shared<std::mutex>()), m_callback_cv(std::make_shared<std::condition_variable>()), m_closed(std::make_shared<bool>())
+        signalr_default_scheduler() : m_internals(std::make_shared<internals>())
         {
             run();
         }
@@ -43,10 +50,19 @@ namespace signalr
 
     private:
         void run();
-        std::shared_ptr<std::vector<std::pair<signalr_base_cb, std::chrono::time_point<std::chrono::steady_clock, std::chrono::nanoseconds>>>> m_callbacks;
-        std::shared_ptr<std::mutex> m_callback_lock;
-        std::shared_ptr<std::condition_variable> m_callback_cv;
-        std::shared_ptr<bool> m_closed;
+
+#pragma warning( push )
+#pragma warning( disable: 4625 5026 4626 5027 )
+        struct internals
+        {
+            std::vector<std::pair<signalr_base_cb, std::chrono::time_point<std::chrono::steady_clock, std::chrono::nanoseconds>>> m_callbacks;
+            std::mutex m_callback_lock;
+            std::condition_variable m_callback_cv;
+            bool m_closed;
+        };
+#pragma warning( pop )
+
+        std::shared_ptr<internals> m_internals;
 
         void close();
     };

--- a/src/signalrclient/signalr_default_scheduler.h
+++ b/src/signalrclient/signalr_default_scheduler.h
@@ -40,9 +40,6 @@ namespace signalr
         std::thread m_thread;
     };
 
-#pragma warning( push )
-    // not all virtual functions of the base class are overridden
-#pragma warning( disable : 4266 )
     struct signalr_default_scheduler : scheduler
     {
         signalr_default_scheduler() : m_internals(std::make_shared<internals>())
@@ -73,7 +70,6 @@ namespace signalr
 
         void close();
     };
-#pragma warning( pop )
 
     void timer_internal(const std::shared_ptr<scheduler>& scheduler, std::function<bool(std::chrono::milliseconds)> func, std::chrono::milliseconds duration);
     void timer(const std::shared_ptr<scheduler>& scheduler, std::function<bool(std::chrono::milliseconds)> func);

--- a/src/signalrclient/signalr_default_scheduler.h
+++ b/src/signalrclient/signalr_default_scheduler.h
@@ -12,7 +12,7 @@ namespace signalr
     {
     public:
         thread();
-        void add(std::pair<signalr_base_cb, std::chrono::time_point<std::chrono::steady_clock, std::chrono::nanoseconds>>);
+        void add(signalr_base_cb);
         bool is_free() const;
         void shutdown();
         ~thread();
@@ -21,7 +21,7 @@ namespace signalr
 #pragma warning( disable: 4625 5026 4626 5027 )
         struct internals
         {
-            std::vector<std::pair<signalr_base_cb, std::chrono::time_point<std::chrono::steady_clock, std::chrono::nanoseconds>>> m_callbacks;
+            std::vector<signalr_base_cb> m_callbacks;
             std::mutex m_callback_lock;
             std::condition_variable m_callback_cv;
             bool m_closed;

--- a/src/signalrclient/signalr_default_scheduler.h
+++ b/src/signalrclient/signalr_default_scheduler.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "../include/signalrclient/scheduler.h"
+#include <thread>
 
 namespace signalr
 {
@@ -12,6 +13,9 @@ namespace signalr
     {
     public:
         thread();
+        thread(const thread&) = delete;
+        thread& operator=(const thread&) = delete;
+
         void add(signalr_base_cb);
         bool is_free() const;
         void shutdown();
@@ -30,6 +34,7 @@ namespace signalr
 #pragma warning( pop )
 
         std::shared_ptr<internals> m_internals;
+        std::thread m_thread;
     };
 
 #pragma warning( push )

--- a/src/signalrclient/transport_factory.cpp
+++ b/src/signalrclient/transport_factory.cpp
@@ -9,8 +9,9 @@
 
 namespace signalr
 {
-    transport_factory::transport_factory(std::shared_ptr<http_client> http_client, std::function<std::shared_ptr<websocket_client>(const signalr_client_config&)> websocket_factory)
-        : m_http_client(http_client), m_websocket_factory(websocket_factory)
+    transport_factory::transport_factory(std::function<std::shared_ptr<http_client>(const signalr_client_config&)> http_client_factory,
+        std::function<std::shared_ptr<websocket_client>(const signalr_client_config&)> websocket_factory)
+        : m_http_client_factory(http_client_factory), m_websocket_factory(websocket_factory)
     {}
 
     std::shared_ptr<transport> transport_factory::create_transport(transport_type transport_type, const logger& logger,

--- a/src/signalrclient/transport_factory.h
+++ b/src/signalrclient/transport_factory.h
@@ -17,14 +17,15 @@ namespace signalr
     class transport_factory
     {
     public:
-        transport_factory(std::shared_ptr<http_client> http_client, std::function<std::shared_ptr<websocket_client>(const signalr_client_config&)> websocket_factory);
+        transport_factory(std::function<std::shared_ptr<http_client>(const signalr_client_config&)>,
+            std::function<std::shared_ptr<websocket_client>(const signalr_client_config&)> websocket_factory);
 
         virtual std::shared_ptr<transport> create_transport(transport_type transport_type, const logger& logger,
             const signalr_client_config& signalr_client_config);
 
         virtual ~transport_factory();
     private:
-        std::shared_ptr<http_client> m_http_client;
+        std::function<std::shared_ptr<http_client>(const signalr_client_config&)> m_http_client_factory;
         std::function<std::shared_ptr<websocket_client>(const signalr_client_config&)> m_websocket_factory;
     };
 }

--- a/test/signalrclienttests/CMakeLists.txt
+++ b/test/signalrclienttests/CMakeLists.txt
@@ -18,6 +18,7 @@ set (SOURCES
   test_websocket_client.cpp
   url_builder_tests.cpp
   websocket_transport_tests.cpp
+  signalr_default_scheduler_tests.cpp
 )
 
 include_directories(

--- a/test/signalrclienttests/connection_impl_tests.cpp
+++ b/test/signalrclienttests/connection_impl_tests.cpp
@@ -11,7 +11,6 @@
 #include "signalrclient/signalr_exception.h"
 #include "signalrclient/web_exception.h"
 #include "test_http_client.h"
-#include "../src/signalrclient/signalr_default_scheduler.h"
 
 using namespace signalr;
 

--- a/test/signalrclienttests/connection_impl_tests.cpp
+++ b/test/signalrclienttests/connection_impl_tests.cpp
@@ -15,11 +15,15 @@
 
 using namespace signalr;
 
-static std::shared_ptr<connection_impl> create_connection(std::shared_ptr<websocket_client> websocket_client = create_test_websocket_client(),
+static std::shared_ptr<connection_impl> create_connection(std::shared_ptr<test_websocket_client> websocket_client = create_test_websocket_client(),
     std::shared_ptr<log_writer> log_writer = std::make_shared<memory_log_writer>(), trace_level trace_level = trace_level::verbose)
 {
     return connection_impl::create(create_uri(), std::make_shared<signalr_default_scheduler>(), trace_level, log_writer, create_test_http_client(),
-        [websocket_client](const signalr_client_config&) { return websocket_client; });
+        [websocket_client](const signalr_client_config& config)
+        {
+            websocket_client->set_config(config);
+            return websocket_client;
+        });
 }
 
 TEST(connection_impl_connection_state, initial_connection_state_is_disconnected)
@@ -31,8 +35,7 @@ TEST(connection_impl_connection_state, initial_connection_state_is_disconnected)
 
 TEST(connection_impl_start, cannot_start_non_disconnected_exception)
 {
-    auto websocket_client = create_test_websocket_client();
-    auto connection = create_connection(websocket_client);
+    auto connection = create_connection();
 
     auto mre = manual_reset_event<void>();
     connection->start([&mre](std::exception_ptr exception)
@@ -94,8 +97,7 @@ TEST(connection_impl_start, connection_state_is_connecting_when_connection_is_be
 
 TEST(connection_impl_start, connection_state_is_connected_when_connection_established_succesfully)
 {
-    auto websocket_client = create_test_websocket_client();
-    auto connection = create_connection(websocket_client);
+    auto connection = create_connection();
     auto mre = manual_reset_event<void>();
     connection->start([&mre](std::exception_ptr exception)
         {
@@ -174,7 +176,11 @@ TEST(connection_impl_start, start_sets_id_query_string)
         });
 
     auto connection = connection_impl::create(create_uri(""), std::make_shared<signalr_default_scheduler>(), trace_level::error, writer, create_test_http_client(),
-        [websocket_client](const signalr_client_config&) { return websocket_client; });
+        [websocket_client](const signalr_client_config& config)
+        {
+            websocket_client->set_config(config);
+            return websocket_client;
+        });
 
     auto mre = manual_reset_event<void>();
     connection->start([&mre](std::exception_ptr exception)
@@ -208,8 +214,12 @@ TEST(connection_impl_start, start_appends_id_query_string)
             callback(std::make_exception_ptr(std::runtime_error("connecting failed")));
         });
 
-    auto connection = connection_impl::create(create_uri("a=b&c=d"), std::make_shared<signalr_default_scheduler>(), trace_level::error, writer, create_test_http_client(),
-        [websocket_client](const signalr_client_config&) { return websocket_client; });
+    auto connection = connection_impl::create(create_uri("a=b&c=d"), std::make_shared<signalr_default_scheduler>(), trace_level::errors,
+        writer, create_test_http_client(), [websocket_client](const signalr_client_config& config)
+        {
+            websocket_client->set_config(config);
+            return websocket_client;
+        });
 
     auto mre = manual_reset_event<void>();
     connection->start([&mre](std::exception_ptr exception)
@@ -584,7 +594,11 @@ TEST(connection_impl_start, negotiate_follows_redirect)
 
     auto connection =
         connection_impl::create(create_uri(), std::make_shared<signalr_default_scheduler>(), trace_level::info, writer,
-            std::move(http_client), [websocket_client](const signalr_client_config&) { return websocket_client; });
+            std::move(http_client), [websocket_client](const signalr_client_config& config)
+            {
+                websocket_client->set_config(config);
+                return websocket_client;
+            });
 
     auto mre = manual_reset_event<void>();
     connection->start([&mre](std::exception_ptr exception)
@@ -633,7 +647,11 @@ TEST(connection_impl_start, negotiate_redirect_uses_accessToken)
 
     auto connection =
         connection_impl::create(create_uri(), std::make_shared<signalr_default_scheduler>(), trace_level::info, writer,
-            std::move(http_client), [websocket_client](const signalr_client_config&) { return websocket_client; });
+            std::move(http_client), [websocket_client](const signalr_client_config& config)
+            {
+                websocket_client->set_config(config);
+                return websocket_client;
+            });
 
     auto mre = manual_reset_event<void>();
     connection->start([&mre](std::exception_ptr exception)
@@ -752,7 +770,11 @@ TEST(connection_impl_start, negotiate_redirect_does_not_overwrite_url)
 
     auto connection =
         connection_impl::create(create_uri(), std::make_shared<signalr_default_scheduler>(), trace_level::info, writer,
-            std::move(http_client), [websocket_client](const signalr_client_config&) { return websocket_client; });
+            std::move(http_client), [websocket_client](const signalr_client_config& config)
+            {
+                websocket_client->set_config(config);
+                return websocket_client;
+            });
 
     auto mre = manual_reset_event<void>();
     connection->start([&mre](std::exception_ptr exception)
@@ -808,8 +830,12 @@ TEST(connection_impl_start, negotiate_redirect_uses_own_query_string)
             return http_response{ 200, response_body };
         }));
 
-    auto connection = connection_impl::create(create_uri("a=b&c=d"), std::make_shared<signalr_default_scheduler>(), trace_level::error, writer, std::move(http_client),
-        [websocket_client](const signalr_client_config&) { return websocket_client; });
+    auto connection = connection_impl::create(create_uri("a=b&c=d"), std::make_shared<signalr_default_scheduler>(), trace_level::errors, writer,
+        std::move(http_client), [websocket_client](const signalr_client_config& config)
+        {
+            websocket_client->set_config(config);
+            return websocket_client;
+        });
 
     auto mre = manual_reset_event<void>();
     connection->start([&mre](std::exception_ptr exception)
@@ -856,8 +882,12 @@ TEST(connection_impl_start, negotiate_with_negotiateVersion_uses_connectionToken
             return http_response{ 200, response_body };
         }));
 
-    auto connection = connection_impl::create(create_uri(), std::make_shared<signalr_default_scheduler>(), trace_level::error, writer, std::move(http_client),
-        [websocket_client](const signalr_client_config&) { return websocket_client; });
+    auto connection = connection_impl::create(create_uri(), std::make_shared<signalr_default_scheduler>(), trace_level::errors, writer,
+        std::move(http_client), [websocket_client](const signalr_client_config& config)
+        {
+            websocket_client->set_config(config);
+            return websocket_client;
+        });
 
     auto mre = manual_reset_event<void>();
     connection->start([&mre](std::exception_ptr exception)
@@ -902,8 +932,12 @@ TEST(connection_impl_start, correct_connection_id_returned_with_negotiateVersion
             return http_response{ 200, response_body };
         }));
 
-    auto connection = connection_impl::create(create_uri(), std::make_shared<signalr_default_scheduler>(), trace_level::error, writer, std::move(http_client),
-        [websocket_client](const signalr_client_config&) { return websocket_client; });
+    auto connection = connection_impl::create(create_uri(), std::make_shared<signalr_default_scheduler>(), trace_level::errors, writer,
+        std::move(http_client), [websocket_client](const signalr_client_config& config)
+        {
+            websocket_client->set_config(config);
+            return websocket_client;
+        });
 
     auto mre = manual_reset_event<void>();
     connection->start([&mre](std::exception_ptr exception)
@@ -934,7 +968,11 @@ TEST(connection_impl_start, start_fails_if_connect_request_times_out)
 
     auto connection =
         connection_impl::create(create_uri(), std::make_shared<signalr_default_scheduler>(), trace_level::info, writer,
-            std::move(http_client), [websocket_client](const signalr_client_config&) { return websocket_client; });
+            std::move(http_client), [websocket_client](const signalr_client_config& config)
+            {
+                websocket_client->set_config(config);
+                return websocket_client;
+            });
 
     auto mre = manual_reset_event<void>();
     connection->start([&mre](std::exception_ptr exception)
@@ -1505,7 +1543,11 @@ TEST(connection_impl_stop, stop_cancels_ongoing_start_request)
 
     auto writer = std::shared_ptr<log_writer>{ std::make_shared<memory_log_writer>() };
     auto connection = connection_impl::create(create_uri(), std::make_shared<signalr_default_scheduler>(), trace_level::verbose, writer,
-        std::move(http_client), [websocket_client](const signalr_client_config&) { return websocket_client; });
+        std::move(http_client), [websocket_client](const signalr_client_config& config)
+        {
+            websocket_client->set_config(config);
+            return websocket_client;
+        });
 
     auto mre = manual_reset_event<void>();
     connection->start([&mre](std::exception_ptr exception)
@@ -1564,7 +1606,11 @@ TEST(connection_impl_stop, DISABLED_ongoing_start_request_canceled_if_connection
 
     auto writer = std::shared_ptr<log_writer>{ std::make_shared<memory_log_writer>() };
     auto connection = connection_impl::create(create_uri(), std::make_shared<signalr_default_scheduler>(), trace_level::verbose, writer,
-        std::move(http_client), [websocket_client](const signalr_client_config&) { return websocket_client; });
+        std::move(http_client), [websocket_client](const signalr_client_config& config)
+        {
+            websocket_client->set_config(config);
+            return websocket_client;
+        });
 
     auto mre = manual_reset_event<void>();
     connection->start([&mre](std::exception_ptr exception)
@@ -1730,7 +1776,11 @@ TEST(connection_impl_config, custom_headers_set_in_requests)
 
     auto connection =
         connection_impl::create(create_uri(), std::make_shared<signalr_default_scheduler>(), trace_level::verbose,
-            writer, std::move(http_client), [websocket_client](const signalr_client_config&) { return websocket_client; });
+            writer, std::move(http_client), [websocket_client](const signalr_client_config& config)
+            {
+                websocket_client->set_config(config);
+                return websocket_client;
+            });
 
     signalr::signalr_client_config signalr_client_config{};
     auto http_headers = signalr_client_config.get_http_headers();
@@ -1896,7 +1946,11 @@ TEST(connection_id, connection_id_reset_when_starting_connection)
 
     auto connection =
         connection_impl::create(create_uri(), std::make_shared<signalr_default_scheduler>(), trace_level::none, std::make_shared<memory_log_writer>(),
-            std::move(http_client), [websocket_client](const signalr_client_config&) { return websocket_client; });
+            std::move(http_client), [websocket_client](const signalr_client_config& config)
+            {
+                websocket_client->set_config(config);
+                return websocket_client;
+            });
 
     auto mre = manual_reset_event<void>();
     connection->start([&mre](std::exception_ptr exception)

--- a/test/signalrclienttests/connection_impl_tests.cpp
+++ b/test/signalrclienttests/connection_impl_tests.cpp
@@ -8,6 +8,7 @@
 #include "connection_impl.h"
 #include "signalrclient/trace_level.h"
 #include "memory_log_writer.h"
+#include "signalr_default_scheduler.h"
 #include "signalrclient/signalr_exception.h"
 #include "signalrclient/web_exception.h"
 #include "test_http_client.h"
@@ -139,7 +140,7 @@ TEST(connection_impl_start, throws_for_invalid_uri)
 
     auto websocket_client = create_test_websocket_client();
 
-    auto connection = connection_impl::create(":1\t ä bad_uri&a=b", std::make_shared<signalr_default_scheduler>(), trace_level::error, writer, create_test_http_client(),
+    auto connection = connection_impl::create(":1\t ä bad_uri&a=b", trace_level::error, writer, create_test_http_client(),
         [websocket_client](const signalr_client_config&) { return websocket_client; });
 
     auto mre = manual_reset_event<void>();
@@ -174,7 +175,7 @@ TEST(connection_impl_start, start_sets_id_query_string)
             callback(std::make_exception_ptr(std::runtime_error("connecting failed")));
         });
 
-    auto connection = connection_impl::create(create_uri(""), std::make_shared<signalr_default_scheduler>(), trace_level::error, writer, create_test_http_client(),
+    auto connection = connection_impl::create(create_uri(""), trace_level::error, writer, create_test_http_client(),
         [websocket_client](const signalr_client_config& config)
         {
             websocket_client->set_config(config);
@@ -213,7 +214,7 @@ TEST(connection_impl_start, start_appends_id_query_string)
             callback(std::make_exception_ptr(std::runtime_error("connecting failed")));
         });
 
-    auto connection = connection_impl::create(create_uri("a=b&c=d"), trace_level::errors,
+    auto connection = connection_impl::create(create_uri("a=b&c=d"), trace_level::error,
         writer, create_test_http_client(), [websocket_client](const signalr_client_config& config)
         {
             websocket_client->set_config(config);
@@ -249,7 +250,7 @@ TEST(connection_impl_start, start_logs_exceptions)
         }));
 
     auto connection =
-        connection_impl::create(create_uri(), std::make_shared<signalr_default_scheduler>(), trace_level::error, writer,
+        connection_impl::create(create_uri(), trace_level::error, writer,
             std::move(http_client), nullptr);
 
     auto mre = manual_reset_event<void>();
@@ -386,7 +387,7 @@ TEST(connection_impl_start, start_fails_if_negotiate_request_fails)
     auto websocket_client = std::make_shared<test_websocket_client>();
 
     auto connection =
-        connection_impl::create(create_uri(), std::make_shared<signalr_default_scheduler>(), trace_level::info, writer,
+        connection_impl::create(create_uri(), trace_level::info, writer,
             std::move(http_client), [websocket_client](const signalr_client_config&) { return websocket_client; });
 
     auto mre = manual_reset_event<void>();
@@ -429,7 +430,7 @@ TEST(connection_impl_start, start_fails_if_negotiate_response_has_error)
         });
 
     auto connection =
-        connection_impl::create(create_uri(), std::make_shared<signalr_default_scheduler>(), trace_level::info, writer,
+        connection_impl::create(create_uri(), trace_level::info, writer,
             std::move(http_client), [websocket_client](const signalr_client_config&) { return websocket_client; });
 
     auto mre = manual_reset_event<void>();
@@ -468,7 +469,7 @@ TEST(connection_impl_start, start_fails_if_negotiate_response_does_not_have_webs
     auto websocket_client = std::make_shared<test_websocket_client>();
 
     auto connection =
-        connection_impl::create(create_uri(), std::make_shared<signalr_default_scheduler>(), trace_level::info, writer,
+        connection_impl::create(create_uri(), trace_level::info, writer,
             std::move(http_client), [websocket_client](const signalr_client_config&) { return websocket_client; });
 
     auto mre = manual_reset_event<void>();
@@ -505,7 +506,7 @@ TEST(connection_impl_start, start_fails_if_negotiate_response_does_not_have_tran
     auto websocket_client = std::make_shared<test_websocket_client>();
 
     auto connection =
-        connection_impl::create(create_uri(), std::make_shared<signalr_default_scheduler>(), trace_level::info, writer,
+        connection_impl::create(create_uri(), trace_level::info, writer,
             std::move(http_client), [websocket_client](const signalr_client_config&) { return websocket_client; });
 
     auto mre = manual_reset_event<void>();
@@ -542,7 +543,7 @@ TEST(connection_impl_start, start_fails_if_negotiate_response_is_invalid)
     auto websocket_client = std::make_shared<test_websocket_client>();
 
     auto connection =
-        connection_impl::create(create_uri(), std::make_shared<signalr_default_scheduler>(), trace_level::info, writer,
+        connection_impl::create(create_uri(), trace_level::info, writer,
             std::move(http_client), [websocket_client](const signalr_client_config&) { return websocket_client; });
 
     auto mre = manual_reset_event<void>();
@@ -592,7 +593,7 @@ TEST(connection_impl_start, negotiate_follows_redirect)
         });
 
     auto connection =
-        connection_impl::create(create_uri(), std::make_shared<signalr_default_scheduler>(), trace_level::info, writer,
+        connection_impl::create(create_uri(), trace_level::info, writer,
             std::move(http_client), [websocket_client](const signalr_client_config& config)
             {
                 websocket_client->set_config(config);
@@ -645,7 +646,7 @@ TEST(connection_impl_start, negotiate_redirect_uses_accessToken)
         });
 
     auto connection =
-        connection_impl::create(create_uri(), std::make_shared<signalr_default_scheduler>(), trace_level::info, writer,
+        connection_impl::create(create_uri(), trace_level::info, writer,
             std::move(http_client), [websocket_client](const signalr_client_config& config)
             {
                 websocket_client->set_config(config);
@@ -683,7 +684,7 @@ TEST(connection_impl_start, negotiate_fails_after_too_many_redirects)
     auto websocket_client = std::make_shared<test_websocket_client>();
 
     auto connection =
-        connection_impl::create(create_uri(), std::make_shared<signalr_default_scheduler>(), trace_level::info, writer,
+        connection_impl::create(create_uri(), trace_level::info, writer,
             std::move(http_client), [websocket_client](const signalr_client_config&) { return websocket_client; });
 
     auto mre = manual_reset_event<void>();
@@ -721,7 +722,7 @@ TEST(connection_impl_start, negotiate_fails_if_ProtocolVersion_in_response)
     auto websocket_client = std::make_shared<test_websocket_client>();
 
     auto connection =
-        connection_impl::create(create_uri(), std::make_shared<signalr_default_scheduler>(), trace_level::info, writer,
+        connection_impl::create(create_uri(), trace_level::info, writer,
             std::move(http_client), [websocket_client](const signalr_client_config&) { return websocket_client; });
 
     auto mre = manual_reset_event<void>();
@@ -768,7 +769,7 @@ TEST(connection_impl_start, negotiate_redirect_does_not_overwrite_url)
     auto websocket_client = std::make_shared<test_websocket_client>();
 
     auto connection =
-        connection_impl::create(create_uri(), std::make_shared<signalr_default_scheduler>(), trace_level::info, writer,
+        connection_impl::create(create_uri(), trace_level::info, writer,
             std::move(http_client), [websocket_client](const signalr_client_config& config)
             {
                 websocket_client->set_config(config);
@@ -829,7 +830,7 @@ TEST(connection_impl_start, negotiate_redirect_uses_own_query_string)
             return http_response{ 200, response_body };
         }));
 
-    auto connection = connection_impl::create(create_uri("a=b&c=d"), trace_level::errors, writer,
+    auto connection = connection_impl::create(create_uri("a=b&c=d"), trace_level::error, writer,
         std::move(http_client), [websocket_client](const signalr_client_config& config)
         {
             websocket_client->set_config(config);
@@ -881,7 +882,7 @@ TEST(connection_impl_start, negotiate_with_negotiateVersion_uses_connectionToken
             return http_response{ 200, response_body };
         }));
 
-    auto connection = connection_impl::create(create_uri(), trace_level::errors, writer,
+    auto connection = connection_impl::create(create_uri(), trace_level::error, writer,
         std::move(http_client), [websocket_client](const signalr_client_config& config)
         {
             websocket_client->set_config(config);
@@ -931,7 +932,7 @@ TEST(connection_impl_start, correct_connection_id_returned_with_negotiateVersion
             return http_response{ 200, response_body };
         }));
 
-    auto connection = connection_impl::create(create_uri(), trace_level::errors, writer,
+    auto connection = connection_impl::create(create_uri(), trace_level::error, writer,
         std::move(http_client), [websocket_client](const signalr_client_config& config)
         {
             websocket_client->set_config(config);
@@ -966,7 +967,7 @@ TEST(connection_impl_start, start_fails_if_connect_request_times_out)
         });
 
     auto connection =
-        connection_impl::create(create_uri(), std::make_shared<signalr_default_scheduler>(), trace_level::info, writer,
+        connection_impl::create(create_uri(), trace_level::info, writer,
             std::move(http_client), [websocket_client](const signalr_client_config& config)
             {
                 websocket_client->set_config(config);
@@ -1322,7 +1323,7 @@ TEST(connection_impl_set_configuration, set_disconnected_callback_can_be_set_onl
 TEST(connection_impl_stop, stopping_disconnected_connection_is_no_op)
 {
     std::shared_ptr<log_writer> writer{ std::make_shared<memory_log_writer>() };
-    auto connection = connection_impl::create(create_uri(), std::make_shared<signalr_default_scheduler>(), trace_level::verbose, writer);
+    auto connection = connection_impl::create(create_uri(), trace_level::verbose, writer);
     auto mre = manual_reset_event<void>();
     connection->stop([&mre](std::exception_ptr exception)
         {
@@ -1540,7 +1541,7 @@ TEST(connection_impl_stop, stop_cancels_ongoing_start_request)
         });
 
     auto writer = std::shared_ptr<log_writer>{ std::make_shared<memory_log_writer>() };
-    auto connection = connection_impl::create(create_uri(), std::make_shared<signalr_default_scheduler>(), trace_level::verbose, writer,
+    auto connection = connection_impl::create(create_uri(), trace_level::verbose, writer,
         std::move(http_client), [websocket_client](const signalr_client_config& config)
         {
             websocket_client->set_config(config);
@@ -1579,7 +1580,6 @@ TEST(connection_impl_stop, stop_cancels_ongoing_start_request)
     ASSERT_TRUE(has_log_entry("[info     ] acquired lock in shutdown()\n", log_entries)) << dump_vector(log_entries);
     ASSERT_TRUE(has_log_entry("[info     ] starting the connection has been canceled.\n", log_entries)) << dump_vector(log_entries);
     ASSERT_TRUE(has_log_entry("[verbose  ] connecting -> disconnected\n", log_entries)) << dump_vector(log_entries);
-    ASSERT_TRUE(has_log_entry("[info     ] Stopping was ignored because the connection is already in the disconnected state.\n", log_entries)) << dump_vector(log_entries);
 }
 
 // Test races with start and stop
@@ -1602,7 +1602,7 @@ TEST(connection_impl_stop, DISABLED_ongoing_start_request_canceled_if_connection
     auto websocket_client = create_test_websocket_client();
 
     auto writer = std::shared_ptr<log_writer>{ std::make_shared<memory_log_writer>() };
-    auto connection = connection_impl::create(create_uri(), std::make_shared<signalr_default_scheduler>(), trace_level::verbose, writer,
+    auto connection = connection_impl::create(create_uri(), trace_level::verbose, writer,
         std::move(http_client), [websocket_client](const signalr_client_config& config)
         {
             websocket_client->set_config(config);
@@ -1772,7 +1772,7 @@ TEST(connection_impl_config, custom_headers_set_in_requests)
     auto websocket_client = create_test_websocket_client();
 
     auto connection =
-        connection_impl::create(create_uri(), std::make_shared<signalr_default_scheduler>(), trace_level::verbose,
+        connection_impl::create(create_uri(), trace_level::verbose,
             writer, std::move(http_client), [websocket_client](const signalr_client_config& config)
             {
                 websocket_client->set_config(config);

--- a/test/signalrclienttests/connection_impl_tests.cpp
+++ b/test/signalrclienttests/connection_impl_tests.cpp
@@ -1528,7 +1528,6 @@ TEST(connection_impl_stop, stop_cancels_ongoing_start_request)
         }));
 
     auto wait_for_start_mre = manual_reset_event<void>();
-    auto close_complete = manual_reset_event<void>();
 
     auto websocket_client = create_test_websocket_client(
         [](const std::string&, std::function<void(std::exception_ptr)> callback) { callback(std::make_exception_ptr(std::exception())); },
@@ -1536,9 +1535,6 @@ TEST(connection_impl_stop, stop_cancels_ongoing_start_request)
             wait_for_start_mre.set();
             disconnect_completed_event->wait();
             callback(nullptr);
-        }, [&close_complete](std::function<void(std::exception_ptr)> callback) {
-            callback(nullptr);
-            close_complete.set();
         });
 
     auto writer = std::shared_ptr<log_writer>{ std::make_shared<memory_log_writer>() };
@@ -1572,7 +1568,6 @@ TEST(connection_impl_stop, stop_cancels_ongoing_start_request)
     }
 
     ASSERT_EQ(connection_state::disconnected, connection->get_connection_state());
-    close_complete.get();
 
     auto log_entries = std::dynamic_pointer_cast<memory_log_writer>(writer)->get_log_entries();
 

--- a/test/signalrclienttests/connection_impl_tests.cpp
+++ b/test/signalrclienttests/connection_impl_tests.cpp
@@ -1559,7 +1559,7 @@ TEST(connection_impl_stop, dtor_stops_the_connection)
     // The connection_impl will be destroyed when the last reference to shared_ptr holding is released. This can happen
     // on a different thread in which case the dtor will be invoked on a different thread so we need to wait for this
     // to happen and if it does not the test will fail
-    for (int wait_time_ms = 5; wait_time_ms < 200 && memory_writer->get_log_entries().size() < 4; wait_time_ms <<= 1)
+    for (int wait_time_ms = 5; wait_time_ms < 6000 && memory_writer->get_log_entries().size() < 6; wait_time_ms <<= 1)
     {
         std::this_thread::sleep_for(std::chrono::milliseconds(wait_time_ms));
     }

--- a/test/signalrclienttests/connection_impl_tests.cpp
+++ b/test/signalrclienttests/connection_impl_tests.cpp
@@ -18,7 +18,7 @@ using namespace signalr;
 static std::shared_ptr<connection_impl> create_connection(std::shared_ptr<test_websocket_client> websocket_client = create_test_websocket_client(),
     std::shared_ptr<log_writer> log_writer = std::make_shared<memory_log_writer>(), trace_level trace_level = trace_level::verbose)
 {
-    return connection_impl::create(create_uri(), std::make_shared<signalr_default_scheduler>(), trace_level, log_writer, create_test_http_client(),
+    return connection_impl::create(create_uri(), trace_level, log_writer, create_test_http_client(),
         [websocket_client](const signalr_client_config& config)
         {
             websocket_client->set_config(config);
@@ -115,7 +115,7 @@ TEST(connection_impl_start, connection_state_is_disconnected_when_connection_can
         }));
 
     auto connection =
-        connection_impl::create(create_uri(), std::make_shared<signalr_default_scheduler>(), trace_level::none, std::make_shared<memory_log_writer>(),
+        connection_impl::create(create_uri(), trace_level::none, std::make_shared<memory_log_writer>(),
             std::move(http_client), nullptr);
 
     auto mre = manual_reset_event<void>();
@@ -214,7 +214,7 @@ TEST(connection_impl_start, start_appends_id_query_string)
             callback(std::make_exception_ptr(std::runtime_error("connecting failed")));
         });
 
-    auto connection = connection_impl::create(create_uri("a=b&c=d"), std::make_shared<signalr_default_scheduler>(), trace_level::errors,
+    auto connection = connection_impl::create(create_uri("a=b&c=d"), trace_level::errors,
         writer, create_test_http_client(), [websocket_client](const signalr_client_config& config)
         {
             websocket_client->set_config(config);
@@ -280,7 +280,7 @@ TEST(connection_impl_start, start_propagates_exceptions_from_negotiate)
         }));
 
     auto connection =
-        connection_impl::create(create_uri(), std::make_shared<signalr_default_scheduler>(), trace_level::none,
+        connection_impl::create(create_uri(), trace_level::none,
             std::make_shared<memory_log_writer>(), std::move(http_client), nullptr);
 
     auto mre = manual_reset_event<void>();
@@ -830,7 +830,7 @@ TEST(connection_impl_start, negotiate_redirect_uses_own_query_string)
             return http_response{ 200, response_body };
         }));
 
-    auto connection = connection_impl::create(create_uri("a=b&c=d"), std::make_shared<signalr_default_scheduler>(), trace_level::errors, writer,
+    auto connection = connection_impl::create(create_uri("a=b&c=d"), trace_level::errors, writer,
         std::move(http_client), [websocket_client](const signalr_client_config& config)
         {
             websocket_client->set_config(config);
@@ -882,7 +882,7 @@ TEST(connection_impl_start, negotiate_with_negotiateVersion_uses_connectionToken
             return http_response{ 200, response_body };
         }));
 
-    auto connection = connection_impl::create(create_uri(), std::make_shared<signalr_default_scheduler>(), trace_level::errors, writer,
+    auto connection = connection_impl::create(create_uri(), trace_level::errors, writer,
         std::move(http_client), [websocket_client](const signalr_client_config& config)
         {
             websocket_client->set_config(config);
@@ -932,7 +932,7 @@ TEST(connection_impl_start, correct_connection_id_returned_with_negotiateVersion
             return http_response{ 200, response_body };
         }));
 
-    auto connection = connection_impl::create(create_uri(), std::make_shared<signalr_default_scheduler>(), trace_level::errors, writer,
+    auto connection = connection_impl::create(create_uri(), trace_level::errors, writer,
         std::move(http_client), [websocket_client](const signalr_client_config& config)
         {
             websocket_client->set_config(config);
@@ -1100,7 +1100,7 @@ TEST(connection_impl_send, message_sent)
 TEST(connection_impl_send, send_throws_if_connection_not_connected)
 {
     auto connection =
-        connection_impl::create(create_uri(), std::make_shared<signalr_default_scheduler>(), trace_level::none, std::make_shared<memory_log_writer>());
+        connection_impl::create(create_uri(), trace_level::none, std::make_shared<memory_log_writer>());
 
     auto mre = manual_reset_event<void>();
     connection->send("whatever", transfer_format::text, [&mre](std::exception_ptr exception)
@@ -1940,7 +1940,7 @@ TEST(connection_id, connection_id_reset_when_starting_connection)
         }));
 
     auto connection =
-        connection_impl::create(create_uri(), std::make_shared<signalr_default_scheduler>(), trace_level::none, std::make_shared<memory_log_writer>(),
+        connection_impl::create(create_uri(), trace_level::none, std::make_shared<memory_log_writer>(),
             std::move(http_client), [websocket_client](const signalr_client_config& config)
             {
                 websocket_client->set_config(config);

--- a/test/signalrclienttests/connection_impl_tests.cpp
+++ b/test/signalrclienttests/connection_impl_tests.cpp
@@ -1016,7 +1016,11 @@ TEST(connection_impl_start, negotiate_can_be_skipped)
 
     auto connection =
         connection_impl::create(create_uri(), trace_level::info, writer,
-            std::move(http_client), [websocket_client](const signalr_client_config&) { return websocket_client; }, true);
+            std::move(http_client), [websocket_client](const signalr_client_config& config)
+            {
+                websocket_client->set_config(config);
+                return websocket_client;
+            }, true);
 
     auto mre = manual_reset_event<void>();
     connection->start([&mre](std::exception_ptr exception)

--- a/test/signalrclienttests/connection_impl_tests.cpp
+++ b/test/signalrclienttests/connection_impl_tests.cpp
@@ -1559,7 +1559,7 @@ TEST(connection_impl_stop, dtor_stops_the_connection)
     // The connection_impl will be destroyed when the last reference to shared_ptr holding is released. This can happen
     // on a different thread in which case the dtor will be invoked on a different thread so we need to wait for this
     // to happen and if it does not the test will fail
-    for (int wait_time_ms = 5; wait_time_ms < 6000 && memory_writer->get_log_entries().size() < 6; wait_time_ms <<= 1)
+    for (int wait_time_ms = 5; wait_time_ms < 6000 && memory_writer->get_log_entries().size() < 7; wait_time_ms <<= 1)
     {
         std::this_thread::sleep_for(std::chrono::milliseconds(wait_time_ms));
     }

--- a/test/signalrclienttests/connection_impl_tests.cpp
+++ b/test/signalrclienttests/connection_impl_tests.cpp
@@ -329,7 +329,7 @@ TEST(connection_impl_start, start_fails_if_transport_connect_throws)
     }
 
     auto log_entries = std::dynamic_pointer_cast<memory_log_writer>(writer)->get_log_entries();
-    ASSERT_TRUE(log_entries.size() > 1);
+    ASSERT_TRUE(log_entries.size() > 1) << dump_vector(log_entries);
 
     ASSERT_TRUE(has_log_entry("[error    ] transport could not connect due to: connecting failed\n", log_entries)) << dump_vector(log_entries);
 }
@@ -1330,8 +1330,7 @@ TEST(connection_impl_stop, stopping_disconnected_connection_is_no_op)
     ASSERT_EQ(connection_state::disconnected, connection->get_connection_state());
 
     auto log_entries = std::dynamic_pointer_cast<memory_log_writer>(writer)->get_log_entries();
-
-    ASSERT_EQ(2U, log_entries.size());
+    ASSERT_EQ(2U, log_entries.size()) << dump_vector(log_entries);
     ASSERT_TRUE(has_log_entry("[info     ] stopping connection\n", log_entries)) << dump_vector(log_entries);
     ASSERT_TRUE(has_log_entry("[info     ] acquired lock in shutdown()\n", log_entries)) << dump_vector(log_entries);
 }
@@ -1498,7 +1497,7 @@ TEST(connection_impl_stop, dtor_stops_the_connection)
     // The connection_impl will be destroyed when the last reference to shared_ptr holding is released. This can happen
     // on a different thread in which case the dtor will be invoked on a different thread so we need to wait for this
     // to happen and if it does not the test will fail
-    for (int wait_time_ms = 5; wait_time_ms < 100 && memory_writer->get_log_entries().size() < 4; wait_time_ms <<= 1)
+    for (int wait_time_ms = 5; wait_time_ms < 200 && memory_writer->get_log_entries().size() < 4; wait_time_ms <<= 1)
     {
         std::this_thread::sleep_for(std::chrono::milliseconds(wait_time_ms));
     }

--- a/test/signalrclienttests/connection_impl_tests.cpp
+++ b/test/signalrclienttests/connection_impl_tests.cpp
@@ -1521,14 +1521,20 @@ TEST(connection_impl_stop, can_start_and_stop_connection_multiple_times)
 
     auto log_entries = memory_writer->get_log_entries();
     ASSERT_EQ(16U, log_entries.size()) << dump_vector(log_entries);
-    ASSERT_EQ("[verbose  ] disconnected -> connecting\n", remove_date_from_log_entry(log_entries[0])) << dump_vector(log_entries);
-    ASSERT_EQ("[verbose  ] connecting -> connected\n", remove_date_from_log_entry(log_entries[2])) << dump_vector(log_entries);
-    ASSERT_EQ("[verbose  ] connected -> disconnecting\n", remove_date_from_log_entry(log_entries[5])) << dump_vector(log_entries);
-    ASSERT_EQ("[verbose  ] disconnecting -> disconnected\n", remove_date_from_log_entry(log_entries[7])) << dump_vector(log_entries);
-    ASSERT_EQ("[verbose  ] disconnected -> connecting\n", remove_date_from_log_entry(log_entries[9])) << dump_vector(log_entries);
-    ASSERT_EQ("[verbose  ] connecting -> connected\n", remove_date_from_log_entry(log_entries[11])) << dump_vector(log_entries);
-    ASSERT_EQ("[verbose  ] connected -> disconnecting\n", remove_date_from_log_entry(log_entries[13])) << dump_vector(log_entries);
-    ASSERT_EQ("[verbose  ] disconnecting -> disconnected\n", remove_date_from_log_entry(log_entries[15])) << dump_vector(log_entries);
+
+    auto second_half = std::vector<std::string>(log_entries.begin() + 8, log_entries.end());
+
+    log_entries = std::vector<std::string>(log_entries.begin(), log_entries.begin() + 8);
+
+    ASSERT_TRUE(has_log_entry("[verbose  ] disconnected -> connecting\n", log_entries)) << dump_vector(log_entries);
+    ASSERT_TRUE(has_log_entry("[verbose  ] connecting -> connected\n", log_entries)) << dump_vector(log_entries);
+    ASSERT_TRUE(has_log_entry("[verbose  ] connected -> disconnecting\n", log_entries)) << dump_vector(log_entries);
+    ASSERT_TRUE(has_log_entry("[verbose  ] disconnecting -> disconnected\n", log_entries)) << dump_vector(log_entries);
+
+    ASSERT_TRUE(has_log_entry("[verbose  ] disconnected -> connecting\n", second_half)) << dump_vector(second_half);
+    ASSERT_TRUE(has_log_entry("[verbose  ] connecting -> connected\n", second_half)) << dump_vector(second_half);
+    ASSERT_TRUE(has_log_entry("[verbose  ] connected -> disconnecting\n", second_half)) << dump_vector(second_half);
+    ASSERT_TRUE(has_log_entry("[verbose  ] disconnecting -> disconnected\n", second_half)) << dump_vector(second_half);
 }
 
 TEST(connection_impl_stop, dtor_stops_the_connection)

--- a/test/signalrclienttests/hub_connection_tests.cpp
+++ b/test/signalrclienttests/hub_connection_tests.cpp
@@ -1461,7 +1461,7 @@ public:
             }).detach();
     }
 
-    std::atomic<int> schedule_count = 0;
+    std::atomic<int> schedule_count{ 0 };
 };
 
 TEST(config, can_replace_scheduler)

--- a/test/signalrclienttests/hub_connection_tests.cpp
+++ b/test/signalrclienttests/hub_connection_tests.cpp
@@ -546,7 +546,7 @@ TEST(stop, connection_stopped_when_going_out_of_scope)
     // The underlying connection_impl will be destroyed when the last reference to shared_ptr holding is released. This can happen
     // on a different thread in which case the dtor will be invoked on a different thread so we need to wait for this
     // to happen and if it does not the test will fail. There is nothing we can block on.
-    for (int wait_time_ms = 5; wait_time_ms < 6000 && memory_writer->get_log_entries().size() < 6; wait_time_ms <<= 1)
+    for (int wait_time_ms = 5; wait_time_ms < 6000 && memory_writer->get_log_entries().size() < 7; wait_time_ms <<= 1)
     {
         std::this_thread::sleep_for(std::chrono::milliseconds(wait_time_ms));
     }

--- a/test/signalrclienttests/hub_connection_tests.cpp
+++ b/test/signalrclienttests/hub_connection_tests.cpp
@@ -13,13 +13,17 @@
 
 using namespace signalr;
 
-hub_connection create_hub_connection(std::shared_ptr<websocket_client> websocket_client = create_test_websocket_client(),
+hub_connection create_hub_connection(std::shared_ptr<test_websocket_client> websocket_client = create_test_websocket_client(),
     std::shared_ptr<log_writer> log_writer = std::make_shared<memory_log_writer>(), trace_level trace_level = trace_level::verbose)
 {
     return hub_connection_builder::create(create_uri())
         .with_logging(log_writer, trace_level)
         .with_http_client(create_test_http_client())
-        .with_websocket_factory([websocket_client](const signalr_client_config&) { return websocket_client; })
+        .with_websocket_factory([websocket_client](const signalr_client_config& config)
+            {
+                websocket_client->set_config(config);
+                return websocket_client;
+            })
         .build();
 }
 
@@ -130,7 +134,7 @@ TEST(url, negotiate_appended_to_url)
     }
 }
 
-TEST(start, start_starts_connection)
+TEST(start, starts_connection)
 {
     auto websocket_client = create_test_websocket_client();
     auto hub_connection = create_hub_connection(websocket_client);

--- a/test/signalrclienttests/hub_connection_tests.cpp
+++ b/test/signalrclienttests/hub_connection_tests.cpp
@@ -1468,7 +1468,7 @@ TEST(config, can_replace_scheduler)
 {
     auto websocket_client = create_test_websocket_client();
     auto hub_connection = hub_connection_builder::create(create_uri())
-        .with_logging(std::make_shared<memory_log_writer>(), trace_level::all)
+        .with_logging(std::make_shared<memory_log_writer>(), trace_level::verbose)
         .with_http_client(create_test_http_client())
         .with_websocket_factory([websocket_client](const signalr_client_config& config)
             {

--- a/test/signalrclienttests/hub_connection_tests.cpp
+++ b/test/signalrclienttests/hub_connection_tests.cpp
@@ -546,7 +546,7 @@ TEST(stop, connection_stopped_when_going_out_of_scope)
     // The underlying connection_impl will be destroyed when the last reference to shared_ptr holding is released. This can happen
     // on a different thread in which case the dtor will be invoked on a different thread so we need to wait for this
     // to happen and if it does not the test will fail. There is nothing we can block on.
-    for (int wait_time_ms = 5; wait_time_ms < 6000 && memory_writer->get_log_entries().size() < 7; wait_time_ms <<= 1)
+    for (int wait_time_ms = 5; wait_time_ms < 6000 && memory_writer->get_log_entries().size() < 9; wait_time_ms <<= 1)
     {
         std::this_thread::sleep_for(std::chrono::milliseconds(wait_time_ms));
     }

--- a/test/signalrclienttests/negotiate_tests.cpp
+++ b/test/signalrclienttests/negotiate_tests.cpp
@@ -13,7 +13,7 @@ using namespace signalr;
 TEST(negotiate, request_created_with_correct_url)
 {
     std::string requested_url;
-    auto request_factory = std::make_shared<test_http_client>([&requested_url](const std::string& url, http_request request)
+    auto http_client = std::make_shared<test_http_client>([&requested_url](const std::string& url, http_request request)
     {
         std::string response_body(
             "{ \"connectionId\" : \"f7707523-307d-4cba-9abf-3eef701241e8\", "
@@ -23,10 +23,10 @@ TEST(negotiate, request_created_with_correct_url)
         return http_response(200, response_body);
     });
 
-    request_factory->set_scheduler(std::make_shared<signalr_default_scheduler>());
+    http_client->set_scheduler(std::make_shared<signalr_default_scheduler>());
 
     auto mre = manual_reset_event<void>();
-    negotiate::negotiate((std::shared_ptr<http_client>)request_factory, "http://fake/signalr", signalr_client_config(),
+    negotiate::negotiate(http_client, "http://fake/signalr", signalr_client_config(),
         [&mre](signalr::negotiation_response&&, std::exception_ptr exception)
         {
             mre.set();
@@ -51,7 +51,7 @@ TEST(negotiate, negotiation_request_sent_and_response_serialized)
     request_factory->set_scheduler(std::make_shared<signalr_default_scheduler>());
 
     auto mre = manual_reset_event<negotiation_response>();
-    negotiate::negotiate((std::shared_ptr<http_client>)request_factory, "http://fake/signalr", signalr_client_config(),
+    negotiate::negotiate(request_factory, "http://fake/signalr", signalr_client_config(),
         [&mre](negotiation_response&& response, std::exception_ptr exception)
         {
             mre.set(response);
@@ -83,7 +83,7 @@ TEST(negotiate, negotiation_response_with_redirect)
     request_factory->set_scheduler(std::make_shared<signalr_default_scheduler>());
 
     auto mre = manual_reset_event<negotiation_response>();
-    negotiate::negotiate((std::shared_ptr<http_client>)request_factory, "http://fake/signalr", signalr_client_config(),
+    negotiate::negotiate(request_factory, "http://fake/signalr", signalr_client_config(),
         [&mre](negotiation_response&& response, std::exception_ptr exception)
         {
             mre.set(response);
@@ -112,7 +112,7 @@ TEST(negotiate, negotiation_response_with_negotiateVersion)
     request_factory->set_scheduler(std::make_shared<signalr_default_scheduler>());
 
     auto mre = manual_reset_event<negotiation_response>();
-    negotiate::negotiate((std::shared_ptr<http_client>)request_factory, "http://fake/signalr", signalr_client_config(),
+    negotiate::negotiate(request_factory, "http://fake/signalr", signalr_client_config(),
         [&mre](negotiation_response&& response, std::exception_ptr exception)
         {
             mre.set(response);
@@ -141,7 +141,7 @@ TEST(negotiate, negotiation_response_with_future_negotiateVersion)
     request_factory->set_scheduler(std::make_shared<signalr_default_scheduler>());
 
     auto mre = manual_reset_event<negotiation_response>();
-    negotiate::negotiate((std::shared_ptr<http_client>)request_factory, "http://fake/signalr", signalr_client_config(),
+    negotiate::negotiate(request_factory, "http://fake/signalr", signalr_client_config(),
         [&mre](negotiation_response&& response, std::exception_ptr exception)
         {
             mre.set(response);

--- a/test/signalrclienttests/negotiate_tests.cpp
+++ b/test/signalrclienttests/negotiate_tests.cpp
@@ -13,7 +13,7 @@ using namespace signalr;
 TEST(negotiate, request_created_with_correct_url)
 {
     std::string requested_url;
-    auto http_client = std::make_shared<test_http_client>([&requested_url](const std::string& url, http_request request)
+    auto request_factory = std::make_shared<test_http_client>([&requested_url](const std::string& url, http_request request)
     {
         std::string response_body(
             "{ \"connectionId\" : \"f7707523-307d-4cba-9abf-3eef701241e8\", "
@@ -23,10 +23,10 @@ TEST(negotiate, request_created_with_correct_url)
         return http_response(200, response_body);
     });
 
-    http_client->set_scheduler(std::make_shared<signalr_default_scheduler>());
+    request_factory->set_scheduler(std::make_shared<signalr_default_scheduler>());
 
     auto mre = manual_reset_event<void>();
-    negotiate::negotiate(http_client, "http://fake/signalr", signalr_client_config(),
+    negotiate::negotiate((std::shared_ptr<http_client>)request_factory, "http://fake/signalr", signalr_client_config(),
         [&mre](signalr::negotiation_response&&, std::exception_ptr exception)
         {
             mre.set();
@@ -51,7 +51,7 @@ TEST(negotiate, negotiation_request_sent_and_response_serialized)
     request_factory->set_scheduler(std::make_shared<signalr_default_scheduler>());
 
     auto mre = manual_reset_event<negotiation_response>();
-    negotiate::negotiate(request_factory, "http://fake/signalr", signalr_client_config(),
+    negotiate::negotiate((std::shared_ptr<http_client>)request_factory, "http://fake/signalr", signalr_client_config(),
         [&mre](negotiation_response&& response, std::exception_ptr exception)
         {
             mre.set(response);
@@ -83,7 +83,7 @@ TEST(negotiate, negotiation_response_with_redirect)
     request_factory->set_scheduler(std::make_shared<signalr_default_scheduler>());
 
     auto mre = manual_reset_event<negotiation_response>();
-    negotiate::negotiate(request_factory, "http://fake/signalr", signalr_client_config(),
+    negotiate::negotiate((std::shared_ptr<http_client>)request_factory, "http://fake/signalr", signalr_client_config(),
         [&mre](negotiation_response&& response, std::exception_ptr exception)
         {
             mre.set(response);
@@ -112,7 +112,7 @@ TEST(negotiate, negotiation_response_with_negotiateVersion)
     request_factory->set_scheduler(std::make_shared<signalr_default_scheduler>());
 
     auto mre = manual_reset_event<negotiation_response>();
-    negotiate::negotiate(request_factory, "http://fake/signalr", signalr_client_config(),
+    negotiate::negotiate((std::shared_ptr<http_client>)request_factory, "http://fake/signalr", signalr_client_config(),
         [&mre](negotiation_response&& response, std::exception_ptr exception)
         {
             mre.set(response);
@@ -141,7 +141,7 @@ TEST(negotiate, negotiation_response_with_future_negotiateVersion)
     request_factory->set_scheduler(std::make_shared<signalr_default_scheduler>());
 
     auto mre = manual_reset_event<negotiation_response>();
-    negotiate::negotiate(request_factory, "http://fake/signalr", signalr_client_config(),
+    negotiate::negotiate((std::shared_ptr<http_client>)request_factory, "http://fake/signalr", signalr_client_config(),
         [&mre](negotiation_response&& response, std::exception_ptr exception)
         {
             mre.set(response);

--- a/test/signalrclienttests/negotiate_tests.cpp
+++ b/test/signalrclienttests/negotiate_tests.cpp
@@ -6,13 +6,14 @@
 #include "negotiate.h"
 #include "test_http_client.h"
 #include "test_utils.h"
+#include "signalr_default_scheduler.h"
 
 using namespace signalr;
 
 TEST(negotiate, request_created_with_correct_url)
 {
     std::string requested_url;
-    auto http_client = test_http_client([&requested_url](const std::string& url, http_request request)
+    auto http_client = std::make_shared<test_http_client>([&requested_url](const std::string& url, http_request request)
     {
         std::string response_body(
             "{ \"connectionId\" : \"f7707523-307d-4cba-9abf-3eef701241e8\", "
@@ -21,6 +22,8 @@ TEST(negotiate, request_created_with_correct_url)
         requested_url = url;
         return http_response(200, response_body);
     });
+
+    http_client->set_scheduler(std::make_shared<signalr_default_scheduler>());
 
     auto mre = manual_reset_event<void>();
     negotiate::negotiate(http_client, "http://fake/signalr", signalr_client_config(),
@@ -35,7 +38,7 @@ TEST(negotiate, request_created_with_correct_url)
 
 TEST(negotiate, negotiation_request_sent_and_response_serialized)
 {
-    auto request_factory = test_http_client([](const std::string&, http_request request)
+    auto request_factory = std::make_shared<test_http_client>([](const std::string&, http_request request)
     {
         std::string response_body(
             "{\"connectionId\" : \"f7707523-307d-4cba-9abf-3eef701241e8\", "
@@ -44,6 +47,8 @@ TEST(negotiate, negotiation_request_sent_and_response_serialized)
 
         return http_response(200, response_body);
     });
+
+    request_factory->set_scheduler(std::make_shared<signalr_default_scheduler>());
 
     auto mre = manual_reset_event<negotiation_response>();
     negotiate::negotiate(request_factory, "http://fake/signalr", signalr_client_config(),
@@ -66,7 +71,7 @@ TEST(negotiate, negotiation_request_sent_and_response_serialized)
 
 TEST(negotiate, negotiation_response_with_redirect)
 {
-    auto request_factory = test_http_client([](const std::string&, http_request request)
+    auto request_factory = std::make_shared<test_http_client>([](const std::string&, http_request request)
     {
         std::string response_body(
             "{\"url\" : \"http://redirect\", "
@@ -74,6 +79,8 @@ TEST(negotiate, negotiation_response_with_redirect)
 
         return http_response(200, response_body);
     });
+
+    request_factory->set_scheduler(std::make_shared<signalr_default_scheduler>());
 
     auto mre = manual_reset_event<negotiation_response>();
     negotiate::negotiate(request_factory, "http://fake/signalr", signalr_client_config(),
@@ -90,7 +97,7 @@ TEST(negotiate, negotiation_response_with_redirect)
 
 TEST(negotiate, negotiation_response_with_negotiateVersion)
 {
-    auto request_factory = test_http_client([](const std::string&, http_request request)
+    auto request_factory = std::make_shared<test_http_client>([](const std::string&, http_request request)
         {
             std::string response_body(
                 "{\"connectionId\" : \"f7707523-307d-4cba-9abf-3eef701241e8\", "
@@ -101,6 +108,8 @@ TEST(negotiate, negotiation_response_with_negotiateVersion)
 
             return http_response(200, response_body);
         });
+
+    request_factory->set_scheduler(std::make_shared<signalr_default_scheduler>());
 
     auto mre = manual_reset_event<negotiation_response>();
     negotiate::negotiate(request_factory, "http://fake/signalr", signalr_client_config(),
@@ -117,7 +126,7 @@ TEST(negotiate, negotiation_response_with_negotiateVersion)
 
 TEST(negotiate, negotiation_response_with_future_negotiateVersion)
 {
-    auto request_factory = test_http_client([](const std::string&, http_request request)
+    auto request_factory = std::make_shared<test_http_client>([](const std::string&, http_request request)
         {
             std::string response_body(
                 "{\"connectionId\" : \"f7707523-307d-4cba-9abf-3eef701241e8\", "
@@ -128,6 +137,8 @@ TEST(negotiate, negotiation_response_with_future_negotiateVersion)
 
             return http_response(200, response_body);
         });
+
+    request_factory->set_scheduler(std::make_shared<signalr_default_scheduler>());
 
     auto mre = manual_reset_event<negotiation_response>();
     negotiate::negotiate(request_factory, "http://fake/signalr", signalr_client_config(),

--- a/test/signalrclienttests/signalr_default_scheduler_tests.cpp
+++ b/test/signalrclienttests/signalr_default_scheduler_tests.cpp
@@ -1,0 +1,61 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include "stdafx.h"
+#include "test_utils.h"
+#include "../src/signalrclient/signalr_default_scheduler.h"
+
+using namespace signalr;
+
+TEST(scheduler, callbacks_run_on_different_thread)
+{
+    signalr_default_scheduler scheduler;
+
+    auto current_thread = std::this_thread::get_id();
+    std::thread::id id;
+    auto mre = manual_reset_event<void>();
+    scheduler.schedule([&id, &mre]()
+        {
+            id = std::this_thread::get_id();
+            mre.set();
+        });
+
+    mre.get();
+    ASSERT_NE(current_thread, id);
+}
+
+TEST(scheduler, callback_can_be_called_when_timer_callback_called_first)
+{
+    signalr_default_scheduler scheduler;
+
+    auto mre = manual_reset_event<void>();
+    bool first_callback = false;
+    scheduler.schedule([&first_callback]()
+        {
+            first_callback = true;
+        }, std::chrono::milliseconds(100));
+
+    scheduler.schedule([&mre]()
+        {
+            mre.set();
+        });
+
+    mre.get();
+    ASSERT_FALSE(first_callback);
+}
+
+//TEST(scheduler, scheduler_can_destruct_with_callbacks_registered)
+//{
+//    auto mre = manual_reset_event<void>();
+//    {
+//        signalr_default_scheduler scheduler;
+//
+//        scheduler.schedule([&mre]()
+//            {
+//                mre.set();
+//            }, std::chrono::milliseconds(100));
+//    }
+//
+//    mre.get();
+//}

--- a/test/signalrclienttests/signalr_default_scheduler_tests.cpp
+++ b/test/signalrclienttests/signalr_default_scheduler_tests.cpp
@@ -30,10 +30,12 @@ TEST(scheduler, callback_can_be_called_when_timer_callback_called_first)
     signalr_default_scheduler scheduler;
 
     auto mre = manual_reset_event<void>();
+    auto timer_mre = manual_reset_event<void>();
     bool first_callback = false;
-    scheduler.schedule([&first_callback]()
+    scheduler.schedule([&first_callback, &timer_mre]()
         {
             first_callback = true;
+            timer_mre.set();
         }, std::chrono::milliseconds(100));
 
     scheduler.schedule([&mre]()
@@ -43,6 +45,7 @@ TEST(scheduler, callback_can_be_called_when_timer_callback_called_first)
 
     mre.get();
     ASSERT_FALSE(first_callback);
+    timer_mre.get();
 }
 
 TEST(scheduler, callback_with_delay_is_delayed)
@@ -72,7 +75,7 @@ TEST(scheduler, scheduler_can_destruct_with_callbacks_registered)
 
         scheduler.schedule([]()
             {
-            }, std::chrono::seconds(100));
+            }, std::chrono::seconds(1));
     }
 
     manual_reset_event<void> start_mre{};

--- a/test/signalrclienttests/signalr_default_scheduler_tests.cpp
+++ b/test/signalrclienttests/signalr_default_scheduler_tests.cpp
@@ -25,7 +25,7 @@ TEST(scheduler, callbacks_run_on_different_thread)
     ASSERT_NE(current_thread, id);
 }
 
-TEST(scheduler, callback_can_be_called_when_timer_callback_called_first)
+TEST(scheduler, callback_can_be_called_when_delayed_callback_called_first)
 {
     signalr_default_scheduler scheduler;
 

--- a/test/signalrclienttests/test_http_client.cpp
+++ b/test/signalrclienttests/test_http_client.cpp
@@ -12,13 +12,14 @@ test_http_client::test_http_client(std::function<http_response(const std::string
 
 void test_http_client::send(const std::string& url, const http_request& request, std::function<void(const http_response&, std::exception_ptr)> callback)
 {
-    std::thread([this, url, request, callback]()
+    auto create_reponse = m_http_response;
+    m_scheduler->schedule([create_reponse, url, request, callback]()
         {
             http_response response;
             std::exception_ptr exception;
             try
             {
-                response = m_http_response(url, request);
+                response = create_reponse(url, request);
             }
             catch (...)
             {
@@ -26,5 +27,10 @@ void test_http_client::send(const std::string& url, const http_request& request,
             }
 
             callback(std::move(response), exception);
-        }).detach();
+        });
+}
+
+void test_http_client::set_scheduler(std::shared_ptr<scheduler> scheduler)
+{
+    m_scheduler = scheduler;
 }

--- a/test/signalrclienttests/test_http_client.h
+++ b/test/signalrclienttests/test_http_client.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "signalrclient/http_client.h"
+#include "signalrclient/scheduler.h"
 
 using namespace signalr;
 
@@ -13,6 +14,10 @@ class test_http_client : public http_client
 public:
     test_http_client(std::function<http_response(const std::string& url, http_request request)> create_http_response_fn);
     void send(const std::string& url, const http_request& request, std::function<void(const http_response&, std::exception_ptr)> callback) override;
+
+    void set_scheduler(std::shared_ptr<scheduler> scheduler);
 private:
     std::function<http_response(const std::string& url, http_request request)> m_http_response;
+
+    std::shared_ptr<scheduler> m_scheduler;
 };

--- a/test/signalrclienttests/test_utils.h
+++ b/test/signalrclienttests/test_utils.h
@@ -6,12 +6,13 @@
 
 #include "signalrclient/websocket_client.h"
 #include "signalrclient/http_client.h"
+#include "signalrclient/signalr_client_config.h"
 #include <future>
 
 std::string remove_date_from_log_entry(const std::string &log_entry);
 bool has_log_entry(const std::string& log_entry, const std::vector<std::string>& logs);
 
-std::unique_ptr<signalr::http_client> create_test_http_client();
+std::function<std::shared_ptr<signalr::http_client>(const signalr::signalr_client_config&)> create_test_http_client();
 std::string create_uri();
 std::string create_uri(const std::string& query_string);
 std::vector<std::string> filter_vector(const std::vector<std::string>& source, const std::string& string);

--- a/test/signalrclienttests/test_websocket_client.cpp
+++ b/test/signalrclienttests/test_websocket_client.cpp
@@ -55,7 +55,7 @@ void test_websocket_client::set_config(const signalr_client_config& config)
     m_scheduler = config.get_scheduler();
 }
 
-void test_websocket_client::start(const std::string& url, transfer_format, std::function<void(std::exception_ptr)> callback)
+void test_websocket_client::start(const std::string& url, std::function<void(std::exception_ptr)> callback)
 {
     std::lock_guard<std::mutex> lock(m_receive_lock);
     m_stopped = false;

--- a/test/signalrclienttests/test_websocket_client.h
+++ b/test/signalrclienttests/test_websocket_client.h
@@ -9,6 +9,7 @@
 #include "test_utils.h"
 #include "cancellation_token.h"
 #include <queue>
+#include "signalrclient/signalr_client_config.h"
 
 using namespace signalr;
 
@@ -17,6 +18,8 @@ class test_websocket_client : public websocket_client
 public:
     test_websocket_client();
     ~test_websocket_client();
+
+    void set_config(const signalr_client_config&);
 
     void start(const std::string& url, std::function<void(std::exception_ptr)> callback);
 
@@ -54,6 +57,7 @@ private:
     bool m_stopped;
     manual_reset_event<void> m_receive_waiting;
     cancellation_token m_receive_loop_not_running;
+    std::shared_ptr<scheduler> m_scheduler;
 };
 
 std::shared_ptr<test_websocket_client> create_test_websocket_client(

--- a/test/signalrclienttests/websocket_transport_tests.cpp
+++ b/test/signalrclienttests/websocket_transport_tests.cpp
@@ -26,7 +26,11 @@ TEST(websocket_transport_connect, connect_connects_and_starts_receive_loop)
 
     std::shared_ptr<log_writer> writer(std::make_shared<memory_log_writer>());
 
-    auto ws_transport = websocket_transport::create([&](const signalr_client_config&) { return client; }, signalr_client_config{}, logger(writer, trace_level::info));
+    auto ws_transport = websocket_transport::create([&](const signalr_client_config& config)
+        {
+            client->set_config(config);
+            return client;
+        }, signalr_client_config{}, logger(writer, trace_level::info));
 
     auto mre = manual_reset_event<void>();
     ws_transport->start("ws://fakeuri.org/connect?param=42", [&mre](std::exception_ptr exception)
@@ -54,7 +58,11 @@ TEST(websocket_transport_connect, connect_propagates_exceptions)
         callback(std::make_exception_ptr(std::runtime_error("connecting failed")));
     });
 
-    auto ws_transport = websocket_transport::create([&](const signalr_client_config&){ return client; }, signalr_client_config{}, logger(std::make_shared<trace_log_writer>(), trace_level::none));
+    auto ws_transport = websocket_transport::create([&](const signalr_client_config& config)
+        {
+            client->set_config(config);
+            return client;
+        }, signalr_client_config{}, logger(std::make_shared<trace_log_writer>(), trace_level::none));
 
     try
     {
@@ -81,7 +89,11 @@ TEST(websocket_transport_connect, connect_logs_exceptions)
     });
 
     std::shared_ptr<log_writer> writer(std::make_shared<memory_log_writer>());
-    auto ws_transport = websocket_transport::create([&](const signalr_client_config&){ return client; }, signalr_client_config{}, logger(writer, trace_level::error));
+    auto ws_transport = websocket_transport::create([&](const signalr_client_config& config)
+        {
+            client->set_config(config);
+            return client;
+        }, signalr_client_config{}, logger(writer, trace_level::error));
 
     auto mre = manual_reset_event<void>();
     ws_transport->start("ws://fakeuri.org", [&mre](std::exception_ptr exception)
@@ -108,7 +120,11 @@ TEST(websocket_transport_connect, connect_logs_exceptions)
 TEST(websocket_transport_connect, cannot_call_connect_on_already_connected_transport)
 {
     auto client = std::make_shared<test_websocket_client>();
-    auto ws_transport = websocket_transport::create([&](const signalr_client_config&){ return client; }, signalr_client_config{}, logger(std::make_shared<trace_log_writer>(), trace_level::none));
+    auto ws_transport = websocket_transport::create([&](const signalr_client_config& config)
+        {
+            client->set_config(config);
+            return client;
+        }, signalr_client_config{}, logger(std::make_shared<trace_log_writer>(), trace_level::none));
 
     auto mre = manual_reset_event<void>();
     ws_transport->start("ws://fakeuri.org", [&mre](std::exception_ptr exception)
@@ -135,7 +151,11 @@ TEST(websocket_transport_connect, cannot_call_connect_on_already_connected_trans
 TEST(websocket_transport_connect, can_connect_after_disconnecting)
 {
     auto client = std::make_shared<test_websocket_client>();
-    auto ws_transport = websocket_transport::create([&](const signalr_client_config&){ return client; }, signalr_client_config{}, logger(std::make_shared<trace_log_writer>(), trace_level::none));
+    auto ws_transport = websocket_transport::create([&](const signalr_client_config& config)
+        {
+            client->set_config(config);
+            return client;
+        }, signalr_client_config{}, logger(std::make_shared<trace_log_writer>(), trace_level::none));
 
     auto mre = manual_reset_event<void>();
     ws_transport->start("ws://fakeuri.org", [&mre](std::exception_ptr exception)
@@ -169,7 +189,11 @@ TEST(websocket_transport_send, send_creates_and_sends_websocket_messages)
         callback(nullptr);
     });
 
-    auto ws_transport = websocket_transport::create([&](const signalr_client_config&){ return client; }, signalr_client_config{}, logger(std::make_shared<trace_log_writer>(), trace_level::none));
+    auto ws_transport = websocket_transport::create([&](const signalr_client_config& config)
+        {
+            client->set_config(config);
+            return client;
+        }, signalr_client_config{}, logger(std::make_shared<trace_log_writer>(), trace_level::none));
 
     auto mre = manual_reset_event<void>();
     ws_transport->start("ws://url", [&mre](std::exception_ptr exception)
@@ -199,7 +223,11 @@ TEST(websocket_transport_disconnect, disconnect_closes_websocket)
         callback(nullptr);
     });
 
-    auto ws_transport = websocket_transport::create([&](const signalr_client_config&){ return client; }, signalr_client_config{}, logger(std::make_shared<trace_log_writer>(), trace_level::none));
+    auto ws_transport = websocket_transport::create([&](const signalr_client_config& config)
+        {
+            client->set_config(config);
+            return client;
+        }, signalr_client_config{}, logger(std::make_shared<trace_log_writer>(), trace_level::none));
 
     auto mre = manual_reset_event<void>();
     ws_transport->start("ws://url", [&mre](std::exception_ptr exception)
@@ -228,7 +256,11 @@ TEST(websocket_transport_stop, propogates_exception_from_close)
         callback(std::make_exception_ptr(std::exception()));
     });
 
-    auto ws_transport = websocket_transport::create([&](const signalr_client_config&){ return client; }, signalr_client_config{}, logger(std::make_shared<trace_log_writer>(), trace_level::none));
+    auto ws_transport = websocket_transport::create([&](const signalr_client_config& config)
+        {
+            client->set_config(config);
+            return client;
+        }, signalr_client_config{}, logger(std::make_shared<trace_log_writer>(), trace_level::none));
 
     auto mre = manual_reset_event<void>();
     ws_transport->start("ws://url", [&mre](std::exception_ptr exception)
@@ -261,7 +293,11 @@ TEST(websocket_transport_disconnect, disconnect_logs_exceptions)
 
     std::shared_ptr<log_writer> writer(std::make_shared<memory_log_writer>());
 
-    auto ws_transport = websocket_transport::create([&](const signalr_client_config&){ return client; }, signalr_client_config{}, logger(writer, trace_level::error));
+    auto ws_transport = websocket_transport::create([&](const signalr_client_config& config)
+        {
+            client->set_config(config);
+            return client;
+        }, signalr_client_config{}, logger(writer, trace_level::error));
 
     auto mre = manual_reset_event<void>();
     ws_transport->start("ws://url", [&mre](std::exception_ptr exception)
@@ -306,7 +342,11 @@ TEST(websocket_transport_disconnect, receive_not_called_after_disconnect)
         callback(nullptr);
     });
 
-    auto ws_transport = websocket_transport::create([&](const signalr_client_config&){ return client; }, signalr_client_config{}, logger(std::make_shared<trace_log_writer>(), trace_level::none));
+    auto ws_transport = websocket_transport::create([&](const signalr_client_config& config)
+        {
+            client->set_config(config);
+            return client;
+        }, signalr_client_config{}, logger(std::make_shared<trace_log_writer>(), trace_level::none));
 
     auto mre = manual_reset_event<void>();
     ws_transport->start("ws://fakeuri.org", [&mre](std::exception_ptr)
@@ -351,7 +391,11 @@ TEST(websocket_transport_disconnect, disconnect_is_no_op_if_transport_not_starte
         callback(nullptr);
     });
 
-    auto ws_transport = websocket_transport::create([&](const signalr_client_config&){ return client; }, signalr_client_config{}, logger(std::make_shared<trace_log_writer>(), trace_level::none));
+    auto ws_transport = websocket_transport::create([&](const signalr_client_config& config)
+        {
+            client->set_config(config);
+            return client;
+        }, signalr_client_config{}, logger(std::make_shared<trace_log_writer>(), trace_level::none));
 
     auto mre = manual_reset_event<void>();
     ws_transport->stop([&mre](std::exception_ptr exception)
@@ -380,7 +424,11 @@ void receive_loop_logs_exception_runner(const T& e, const std::string& expected_
     auto client = std::make_shared<test_websocket_client>();
     std::shared_ptr<log_writer> writer(std::make_shared<memory_log_writer>());
 
-    auto ws_transport = websocket_transport::create([&](const signalr_client_config&) { return client; }, signalr_client_config{}, logger(writer, trace_level));
+    auto ws_transport = websocket_transport::create([&](const signalr_client_config& config)
+        {
+            client->set_config(config);
+            return client;
+        }, signalr_client_config{}, logger(writer, trace_level));
 
     auto mre = manual_reset_event<void>();
     ws_transport->start("ws://url", [&mre](std::exception_ptr exception)
@@ -430,7 +478,11 @@ TEST(websocket_transport_receive_loop, process_response_callback_called_when_mes
         process_response_event->cancel();
     };
 
-    auto ws_transport = websocket_transport::create([&](const signalr_client_config&){ return client; }, signalr_client_config{}, logger(std::make_shared<trace_log_writer>(), trace_level::none));
+    auto ws_transport = websocket_transport::create([&](const signalr_client_config& config)
+        {
+            client->set_config(config);
+            return client;
+        }, signalr_client_config{}, logger(std::make_shared<trace_log_writer>(), trace_level::none));
     ws_transport->on_receive(process_response);
 
     auto mre = manual_reset_event<void>();
@@ -474,7 +526,11 @@ TEST(websocket_transport_receive_loop, error_callback_called_when_exception_thro
         error_event->cancel();
     };
 
-    auto ws_transport = websocket_transport::create([&](const signalr_client_config&){ return client; }, signalr_client_config{}, logger(std::make_shared<trace_log_writer>(), trace_level::none));
+    auto ws_transport = websocket_transport::create([&](const signalr_client_config& config)
+        {
+            client->set_config(config);
+            return client;
+        }, signalr_client_config{}, logger(std::make_shared<trace_log_writer>(), trace_level::none));
     ws_transport->on_close(error_callback);
 
     auto mre = manual_reset_event<void>();
@@ -495,7 +551,12 @@ TEST(websocket_transport_receive_loop, error_callback_called_when_exception_thro
 TEST(websocket_transport_get_transport_type, get_transport_type_returns_websockets)
 {
     auto ws_transport = websocket_transport::create(
-        [](const signalr_client_config&){ return std::make_shared<test_websocket_client>(); }, signalr_client_config{},
+        [](const signalr_client_config& config)
+        {
+            auto client = std::make_shared<test_websocket_client>();
+            client->set_config(config);
+            return client;
+        }, signalr_client_config{},
         logger(std::make_shared<trace_log_writer>(), trace_level::none));
 
     ASSERT_EQ(transport_type::websockets, ws_transport->get_transport_type());


### PR DESCRIPTION
Pre-req for https://github.com/dotnet/aspnetcore/issues/8721

Still need to decide if I want to add some cancellation of callbacks, or if I need to modify some of the internals to "cancel" a callback and call the upstream callback inline and ignore the scheduled callback when the thread eventually calls it. Because right now for example, if stop is called while start is in progress there is a 5 second delay and before it was immediate.

The lifetime of the threads/scheduler was the biggest issue, made everything on the default scheduler a `shared_ptr` so the thread shares the object with the class that way if the original class is destructed it doesn't cause AV's with the thread accessing members. Could probably make all the properties a struct and reduce them to a single `shared_ptr` to reduce allocations.

**Edit:**
For the first paragraph, added a "timer" which will call the scheduled method after 1 second and reschedule itself if it isn't ready to be completed.

For the second paragraph, made a single struct for the properties to use a single `shared_ptr` instead of a `shared_ptr` per property.