### PR TITLE
Make hub_connection always a shared_ptr

### DIFF
--- a/include/signalrclient/hub_connection.h
+++ b/include/signalrclient/hub_connection.h
@@ -27,13 +27,10 @@ namespace signalr
 
         SIGNALRCLIENT_API ~hub_connection();
 
-        hub_connection(const hub_connection&) = delete;
-
+        hub_connection(const hub_connection& rhs) = delete;
         hub_connection& operator=(const hub_connection&) = delete;
-
-        SIGNALRCLIENT_API hub_connection(hub_connection&&) noexcept;
-
-        SIGNALRCLIENT_API hub_connection& operator=(hub_connection&&) noexcept;
+        hub_connection(hub_connection&&) = delete;
+        hub_connection& operator=(hub_connection&&) = delete;
 
         SIGNALRCLIENT_API void __cdecl start(std::function<void(std::exception_ptr)> callback) noexcept;
         SIGNALRCLIENT_API void __cdecl stop(std::function<void(std::exception_ptr)> callback) noexcept;

--- a/include/signalrclient/hub_connection_builder.h
+++ b/include/signalrclient/hub_connection_builder.h
@@ -33,7 +33,7 @@ namespace signalr
 
         SIGNALRCLIENT_API hub_connection_builder& with_http_client(std::shared_ptr<http_client> http_client);
 
-        SIGNALRCLIENT_API hub_connection build();
+        SIGNALRCLIENT_API std::shared_ptr<hub_connection> build();
     private:
         hub_connection_builder(const std::string& url);
 

--- a/samples/HubConnectionSample/HubConnectionSample.cpp
+++ b/samples/HubConnectionSample/HubConnectionSample.cpp
@@ -51,17 +51,17 @@ void send_message(signalr::hub_connection& connection, const std::string& messag
 
 void chat()
 {
-    signalr::hub_connection connection = signalr::hub_connection_builder::create("http://localhost:5000/default")
-        .with_logging(std::make_shared <logger>(), signalr::trace_level::all)
+    std::shared_ptr<signalr::hub_connection> connection = signalr::hub_connection_builder::create("http://localhost:5000/default")
+        .with_logging(std::make_shared<logger>(), signalr::trace_level::all)
         .build();
 
-    connection.on("Send", [](const signalr::value & m)
+    connection->on("Send", [](const signalr::value & m)
     {
         std::cout << std::endl << m.as_array()[0].as_string() << std::endl << "Enter your message: ";
     });
 
     std::promise<void> task;
-    connection.start([&connection, &task](std::exception_ptr exception)
+    connection->start([&connection, &task](std::exception_ptr exception)
     {
         if (exception)
         {
@@ -78,20 +78,20 @@ void chat()
         }
 
         std::cout << "Enter your message:";
-        while (connection.get_connection_state() == signalr::connection_state::connected)
+        while (connection->get_connection_state() == signalr::connection_state::connected)
         {
             std::string message;
             std::getline(std::cin, message);
 
-            if (message == ":q" || connection.get_connection_state() != signalr::connection_state::connected)
+            if (message == ":q" || connection->get_connection_state() != signalr::connection_state::connected)
             {
                 break;
             }
 
-            send_message(connection, message);
+            //send_message(connection, message);
         }
 
-        connection.stop([&task](std::exception_ptr exception)
+        connection->stop([&task](std::exception_ptr exception)
         {
             try
             {

--- a/src/signalrclient/hub_connection.cpp
+++ b/src/signalrclient/hub_connection.cpp
@@ -17,17 +17,6 @@ namespace signalr
         : m_pImpl(hub_connection_impl::create(url, trace_level, log_writer, http_client, websocket_factory))
     {}
 
-    hub_connection::hub_connection(hub_connection&& rhs) noexcept
-        : m_pImpl(std::move(rhs.m_pImpl))
-    {}
-
-    hub_connection& hub_connection::operator=(hub_connection&& rhs) noexcept
-    {
-        m_pImpl = std::move(rhs.m_pImpl);
-
-        return *this;
-    }
-
     // Do NOT remove this destructor. Letting the compiler generate and inline the default dtor may lead to
     // undefined behavior since we are using an incomplete type. More details here:  http://herbsutter.com/gotw/_100/
     hub_connection::~hub_connection() = default;

--- a/src/signalrclient/hub_connection_builder.cpp
+++ b/src/signalrclient/hub_connection_builder.cpp
@@ -71,7 +71,7 @@ namespace signalr
         return *this;
     }
 
-    hub_connection hub_connection_builder::build()
+    std::shared_ptr<hub_connection> hub_connection_builder::build()
     {
 #ifndef USE_CPPRESTSDK
         if (m_http_client == nullptr)
@@ -85,6 +85,6 @@ namespace signalr
         }
 #endif
 
-        return hub_connection(m_url, m_log_level, m_logger, m_http_client, m_websocket_factory);
+        return std::shared_ptr<hub_connection>(new hub_connection(m_url, m_log_level, m_logger, m_http_client, m_websocket_factory));
     }
 }


### PR DESCRIPTION
We talked about replacing the hub_connection_impl and making hub_connection contain all the logic. However, that would require including a lot of internal types in the public header and all sorts of ugliness.