### PR TITLE
Better http request timeout handling.

### DIFF
--- a/src/signalrclient/negotiate.cpp
+++ b/src/signalrclient/negotiate.cpp
@@ -30,10 +30,10 @@ namespace signalr
                 return;
             }
 
-            // TODO: signalr_client_config
             http_request request;
             request.method = http_method::POST;
             request.headers = config.get_http_headers();
+            request.timeout = config.get_http_client_config().timeout();
 
             client.send(negotiate_url, request, [callback](const http_response& http_response, std::exception_ptr exception)
             {

--- a/src/signalrclient/negotiate.cpp
+++ b/src/signalrclient/negotiate.cpp
@@ -30,6 +30,7 @@ namespace signalr
                 return;
             }
 
+            // TODO: signalr_client_config
             http_request request;
             request.method = http_method::POST;
             request.headers = config.get_http_headers();

--- a/src/signalrclient/negotiate.cpp
+++ b/src/signalrclient/negotiate.cpp
@@ -33,7 +33,9 @@ namespace signalr
             http_request request;
             request.method = http_method::POST;
             request.headers = config.get_http_headers();
+#ifdef USE_CPPRESTSDK
             request.timeout = config.get_http_client_config().timeout();
+#endif
 
             client.send(negotiate_url, request, [callback](const http_response& http_response, std::exception_ptr exception)
             {


### PR DESCRIPTION
Propagate http timeout configuration to the negotiate request.
Modify the timeout monitor in default_http_client so that task
is completed as soon as result is handled.