### PR TITLE
Add memory leak detection to testing

### DIFF
--- a/.azure/default-build.yml
+++ b/.azure/default-build.yml
@@ -54,7 +54,7 @@ jobs:
         workingDirectory: 'build.${{ parameters.configuration }}'
       displayName: Build client
     - ${{ if eq(parameters.agentOs, 'macOS') }}:
-      - bash: "./run-tests.sh valgrind --leak-check=yes --leak-check=full --error-exitcode=1 --track-origins=yes ./build.${{ parameters.configuration }}/bin/signalrclienttests ${{ parameters.gtestFlags }}"
+      - bash: "./run-tests.sh ./build.${{ parameters.configuration }}/bin/signalrclienttests ${{ parameters.gtestFlags }}"
         condition: eq( variables['Agent.OS'], 'Darwin' )
         displayName: Run tests
     - ${{ if eq(parameters.agentOs, 'Linux') }}:

--- a/.azure/default-build.yml
+++ b/.azure/default-build.yml
@@ -54,11 +54,11 @@ jobs:
         workingDirectory: 'build.${{ parameters.configuration }}'
       displayName: Build client
     - ${{ if eq(parameters.agentOs, 'macOS') }}:
-      - bash: "./run-tests.sh ./build.${{ parameters.configuration }}/bin/signalrclienttests ${{ parameters.gtestFlags }}"
+      - bash: "./run-tests.sh valgrind --leak-check=yes --leak-check=full --error-exitcode=1 --track-origins=yes ./build.${{ parameters.configuration }}/bin/signalrclienttests ${{ parameters.gtestFlags }}"
         condition: eq( variables['Agent.OS'], 'Darwin' )
         displayName: Run tests
     - ${{ if eq(parameters.agentOs, 'Linux') }}:
-      - bash: "./run-tests.sh ./build.${{ parameters.configuration }}/bin/signalrclienttests ${{ parameters.gtestFlags }}"
+      - bash: "./run-tests.sh valgrind --leak-check=yes --leak-check=full --error-exitcode=1 --track-origins=yes ./build.${{ parameters.configuration }}/bin/signalrclienttests ${{ parameters.gtestFlags }}"
         condition: eq( variables['Agent.OS'], 'Linux' )
         displayName: Run tests
     - ${{ if eq(parameters.agentOs, 'Windows') }}:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -85,9 +85,9 @@ stages:
       agentOs: Linux
       jobName: Linux_Build_Test
       useCppRestSDK: false
-    beforeBuild:
-    - bash: "sudo apt install valgrind"
-      displayName: install valgrind
+      beforeBuild:
+      - bash: "sudo apt install valgrind"
+        displayName: install valgrind
 
   - template: .azure/default-build.yml
     parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -87,7 +87,7 @@ stages:
       useCppRestSDK: false
     beforeBuild:
     - bash: "sudo apt install valgrind"
-        displayName: install valgrind
+      displayName: install valgrind
 
   - template: .azure/default-build.yml
     parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -56,8 +56,8 @@ stages:
       # Once the problem has been resolved
       - script: sudo xcode-select --switch /Applications/Xcode_10.3.app
         displayName: xcode-select
-      - script: brew install gcc
-        displayName: Install gcc
+      - script: brew install gcc valgrind
+        displayName: Install gcc and valgrind
       - bash: "./submodules/vcpkg/bootstrap-vcpkg.sh"
         condition: ne(variables.CACHE_RESTORED, 'true')
         displayName: Bootstrap vcpkg
@@ -77,12 +77,17 @@ stages:
       - bash: "./submodules/vcpkg/vcpkg install cpprestsdk boost-system boost-chrono boost-thread --vcpkg-root ./submodules/vcpkg"
         condition: ne(variables.CACHE_RESTORED, 'true')
         displayName: vcpkg install dependencies
+      - bash: "sudo apt install valgrind"
+        displayName: install valgrind
 
   - template: .azure/default-build.yml
     parameters:
       agentOs: Linux
       jobName: Linux_Build_Test
       useCppRestSDK: false
+    beforeBuild:
+    - bash: "sudo apt install valgrind"
+        displayName: install valgrind
 
   - template: .azure/default-build.yml
     parameters:
@@ -101,8 +106,8 @@ stages:
       # Once the problem has been resolved
       - script: sudo xcode-select --switch /Applications/Xcode_10.3.app
         displayName: xcode-select
-      - script: brew install gcc
-        displayName: Install gcc
+      - script: brew install gcc valgrind
+        displayName: Install gcc and valgrind
 
   # Publish to the BAR
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -56,8 +56,8 @@ stages:
       # Once the problem has been resolved
       - script: sudo xcode-select --switch /Applications/Xcode_10.3.app
         displayName: xcode-select
-      - script: brew install gcc valgrind
-        displayName: Install gcc and valgrind
+      - script: brew install gcc
+        displayName: Install gcc
       - bash: "./submodules/vcpkg/bootstrap-vcpkg.sh"
         condition: ne(variables.CACHE_RESTORED, 'true')
         displayName: Bootstrap vcpkg
@@ -106,8 +106,8 @@ stages:
       # Once the problem has been resolved
       - script: sudo xcode-select --switch /Applications/Xcode_10.3.app
         displayName: xcode-select
-      - script: brew install gcc valgrind
-        displayName: Install gcc and valgrind
+      - script: brew install gcc
+        displayName: Install gcc
 
   # Publish to the BAR
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:

--- a/src/signalrclient/signalr_value.cpp
+++ b/src/signalrclient/signalr_value.cpp
@@ -182,7 +182,7 @@ namespace signalr
 
     value& value::operator=(const value& rhs)
     {
-        destruct_internals();
+        //destruct_internals();
 
         mType = rhs.mType;
         switch (mType)

--- a/src/signalrclient/signalr_value.cpp
+++ b/src/signalrclient/signalr_value.cpp
@@ -182,7 +182,7 @@ namespace signalr
 
     value& value::operator=(const value& rhs)
     {
-        //destruct_internals();
+        destruct_internals();
 
         mType = rhs.mType;
         switch (mType)

--- a/test/signalrclienttests/signalrclienttests.cpp
+++ b/test/signalrclienttests/signalrclienttests.cpp
@@ -11,6 +11,22 @@ int wmain(int argc, wchar_t* argv[])
 int main(int argc, char* argv[])
 #endif
 {
+#if defined(_WIN32)
+    _CrtSetDbgFlag(_CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF);
+    _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE | _CRTDBG_MODE_DEBUG);
+    _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
+    _CrtSetReportMode(_CRT_ERROR, _CRTDBG_MODE_FILE | _CRTDBG_MODE_DEBUG);
+    _CrtSetReportFile(_CRT_ERROR, _CRTDBG_FILE_STDERR);
+    _CrtSetReportMode(_CRT_WARN, _CRTDBG_MODE_FILE | _CRTDBG_MODE_DEBUG);
+    _CrtSetReportFile(_CRT_WARN, _CRTDBG_FILE_STDERR);
+#endif
+
     ::testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
+    auto res = RUN_ALL_TESTS();
+
+    // Test code currently uses detached threads which can look like a leak if they haven't cleaned up by program exit
+    // Until test code properly tracks threads we can workaround the false leaks by waiting a little bit
+    std::this_thread::sleep_for(std::chrono::seconds(5));
+
+    return res;
 }

--- a/test/signalrclienttests/stdafx.h
+++ b/test/signalrclienttests/stdafx.h
@@ -7,6 +7,9 @@
 #ifdef _WIN32
 // prevents from defining min/max macros that conflict with std::min()/std::max() functions
 #define NOMINMAX
+#define WIN32_LEAN_AND_MEAN
+#define _CRTDBG_MAP_ALLOC
+#include <crtdbg.h>
 #endif
 
 #include "gtest/gtest.h"


### PR DESCRIPTION
Linux PR builds (with exit code 1 on leaks)
```
==77190== 
==77190== HEAP SUMMARY:
==77190==     in use at exit: 72,816 bytes in 2 blocks
==77190==   total heap usage: 53,321 allocs, 53,319 frees, 5,137,654 bytes allocated
==77190== 
==77190== 112 bytes in 1 blocks are definitely lost in loss record 1 of 2
==77190==    at 0x4C2E0EF: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==77190==    by 0x52EE9D7: signalr::value::operator=(signalr::value const&) (in /home/vsts/work/1/s/build.Release/bin/libsignalrclient.so)
==77190==    by 0x459D52: std::_Function_handler<void (signalr::value const&), hub_invocation_hub_connection_can_receive_multiple_messages_in_same_payload_Test::TestBody()::{lambda(signalr::value const&)#1}>::_M_invoke(std::_Any_data const&, signalr::value const&) (in /home/vsts/work/1/s/build.Release/bin/signalrclienttests)
==77190==    by 0x52E1112: signalr::hub_connection_impl::process_message(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&&) (in /home/vsts/work/1/s/build.Release/bin/libsignalrclient.so)
==77190==    by 0x52E18B8: std::_Function_handler<void (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&&), signalr::hub_connection_impl::initialize()::{lambda(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&&)#1}>::_M_invoke(std::_Any_data const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&&) (in /home/vsts/work/1/s/build.Release/bin/libsignalrclient.so)
==77190==    by 0x52AADDB: signalr::connection_impl::invoke_message_received(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&&) (in /home/vsts/work/1/s/build.Release/bin/libsignalrclient.so)
==77190==    by 0x52AAF7E: signalr::connection_impl::process_response(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&&) (in /home/vsts/work/1/s/build.Release/bin/libsignalrclient.so)
==77190==    by 0x52ABA1F: std::_Function_handler<void (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&&, std::__exception_ptr::exception_ptr), signalr::connection_impl::start_transport(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::function<void (std::shared_ptr<signalr::transport>, std::__exception_ptr::exception_ptr)>)::{lambda(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&&, std::__exception_ptr::exception_ptr)#2}>::_M_invoke(std::_Any_data const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&&, std::__exception_ptr::exception_ptr&&) (in /home/vsts/work/1/s/build.Release/bin/libsignalrclient.so)
==77190==    by 0x52F5B09: std::_Function_handler<void (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__exception_ptr::exception_ptr), std::function<void (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&&, std::__exception_ptr::exception_ptr)> >::_M_invoke(std::_Any_data const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&&, std::__exception_ptr::exception_ptr&&) (in /home/vsts/work/1/s/build.Release/bin/libsignalrclient.so)
==77190==    by 0x52F3DFF: std::_Function_handler<void (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__exception_ptr::exception_ptr), signalr::websocket_transport::receive_loop(std::shared_ptr<signalr::cancellation_token>)::{lambda(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__exception_ptr::exception_ptr)#1}>::_M_invoke(std::_Any_data const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__exception_ptr::exception_ptr&&) (in /home/vsts/work/1/s/build.Release/bin/libsignalrclient.so)
==77190==    by 0x498275: std::thread::_Impl<std::_Bind_simple<test_websocket_client::receive(std::function<void (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__exception_ptr::exception_ptr)>)::{lambda()#1} ()> >::_M_run() (in /home/vsts/work/1/s/build.Release/bin/signalrclienttests)
==77190==    by 0x5C4FE5D: ??? (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.28)
==77190== 
==77190== LEAK SUMMARY:
==77190==    definitely lost: 112 bytes in 1 blocks
==77190==    indirectly lost: 0 bytes in 0 blocks
==77190==      possibly lost: 0 bytes in 0 blocks
==77190==    still reachable: 72,704 bytes in 1 blocks
==77190==         suppressed: 0 bytes in 0 blocks
==77190== Reachable blocks (those to which a pointer was found) are not shown.
==77190== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==77190== 
==77190== For counts of detected and suppressed errors, rerun with: -v
==77190== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
Finished running with exit code: 1
```

Locally when running Windows Debug tests
```
Detected memory leaks!
Dumping objects ->
{78179} normal block at 0x000002905D51C960, 16 bytes long.
 Data: <x P]            > 78 FA 50 5D 90 02 00 00 00 00 00 00 00 00 00 00
{78178} normal block at 0x000002905D50FA70, 96 bytes long.
 Data: <        ` Q]    > 02 00 00 00 CD CD CD CD 60 C9 51 5D 90 02 00 00
{78177} normal block at 0x000002905D51C190, 16 bytes long.
 Data: <  O]            > D8 8E 4F 5D 90 02 00 00 00 00 00 00 00 00 00 00
Object dump complete.
```