### PR TITLE
Logging improvements

### DIFF
--- a/include/signalrclient/connection.h
+++ b/include/signalrclient/connection.h
@@ -22,7 +22,7 @@ namespace signalr
     public:
         typedef std::function<void __cdecl(const std::string&)> message_received_handler;
 
-        SIGNALRCLIENT_API explicit connection(const std::string& url, trace_level trace_level = trace_level::all, std::shared_ptr<log_writer> log_writer = nullptr);
+        SIGNALRCLIENT_API explicit connection(const std::string& url, trace_level trace_level = trace_level::info, std::shared_ptr<log_writer> log_writer = nullptr);
 
         SIGNALRCLIENT_API ~connection();
 

--- a/include/signalrclient/hub_connection.h
+++ b/include/signalrclient/hub_connection.h
@@ -54,7 +54,7 @@ namespace signalr
     private:
         friend class hub_connection_builder;
 
-        explicit hub_connection(const std::string& url, trace_level trace_level = trace_level::all,
+        explicit hub_connection(const std::string& url, trace_level trace_level = trace_level::info,
             std::shared_ptr<log_writer> log_writer = nullptr, std::shared_ptr<http_client> http_client = nullptr,
             std::function<std::shared_ptr<websocket_client>(const signalr_client_config&)> websocket_factory = nullptr, bool skip_negotiation = false);
 

--- a/include/signalrclient/trace_level.h
+++ b/include/signalrclient/trace_level.h
@@ -8,22 +8,12 @@ namespace signalr
 {
     enum class trace_level : int
     {
-        none = 0,
-        messages = 1,
-        events = 2,
-        state_changes = 4,
-        errors = 8,
-        info = 16,
-        all = messages | events | state_changes | errors | info
+        verbose = 0,
+        debug = 1,
+        info = 2,
+        warning = 3,
+        error = 4,
+        critical = 5,
+        none = 6,
     };
-
-    inline trace_level operator|(trace_level lhs, trace_level rhs) noexcept
-    {
-        return static_cast<trace_level>(static_cast<int>(lhs) | static_cast<int>(rhs));
-    }
-
-    inline trace_level operator&(trace_level lhs, trace_level rhs) noexcept
-    {
-        return static_cast<trace_level>(static_cast<int>(lhs) & static_cast<int>(rhs));
-    }
 }

--- a/samples/HubConnectionSample/HubConnectionSample.cpp
+++ b/samples/HubConnectionSample/HubConnectionSample.cpp
@@ -52,7 +52,7 @@ void send_message(signalr::hub_connection& connection, const std::string& messag
 void chat()
 {
     signalr::hub_connection connection = signalr::hub_connection_builder::create("http://localhost:5000/default")
-        .with_logging(std::make_shared <logger>(), signalr::trace_level::all)
+        .with_logging(std::make_shared <logger>(), signalr::trace_level::verbose)
         .build();
 
     connection.on("Send", [](const signalr::value & m)

--- a/src/signalrclient/hub_connection_impl.cpp
+++ b/src/signalrclient/hub_connection_impl.cpp
@@ -236,8 +236,11 @@ namespace signalr
                 if (found != obj.end())
                 {
                     auto& error = found->second.as_string();
-                    m_logger.log(trace_level::errors, std::string("handshake error: ")
-                        .append(error));
+                    if (m_logger.is_enabled(trace_level::error))
+                    {
+                        m_logger.log(trace_level::error, std::string("handshake error: ")
+                            .append(error));
+                    }
                     m_handshakeTask->set(std::make_exception_ptr(signalr_exception(std::string("Received an error during handshake: ").append(error))));
                     return;
                 }
@@ -306,10 +309,13 @@ namespace signalr
         }
         catch (const std::exception &e)
         {
-            m_logger.log(trace_level::errors, std::string("error occured when parsing response: ")
-                .append(e.what())
-                .append(". response: ")
-                .append(response));
+            if (m_logger.is_enabled(trace_level::error))
+            {
+                m_logger.log(trace_level::error, std::string("error occured when parsing response: ")
+                    .append(e.what())
+                    .append(". response: ")
+                    .append(response));
+            }
 
             // TODO: Consider passing "reason" exception to stop
             m_connection->stop([](std::exception_ptr) {});
@@ -328,7 +334,16 @@ namespace signalr
         // worry about object lifetime
         if (!m_callback_manager.invoke_callback(completion->invocation_id, error, completion->result, true))
         {
-            m_logger.log(trace_level::info, std::string("no callback found for id: ").append(completion->invocation_id));
+            throw signalr_exception("invocationId is not a string");
+        }
+
+        auto& id = invocationId.as_string();
+        if (!m_callback_manager.invoke_callback(id, message, true))
+        {
+            if (m_logger.is_enabled(trace_level::info))
+            {
+                m_logger.log(trace_level::info, std::string("no callback found for id: ").append(id));
+            }
             return false;
         }
 

--- a/src/signalrclient/hub_connection_impl.cpp
+++ b/src/signalrclient/hub_connection_impl.cpp
@@ -334,17 +334,10 @@ namespace signalr
         // worry about object lifetime
         if (!m_callback_manager.invoke_callback(completion->invocation_id, error, completion->result, true))
         {
-            throw signalr_exception("invocationId is not a string");
-        }
-
-        auto& id = invocationId.as_string();
-        if (!m_callback_manager.invoke_callback(id, message, true))
-        {
             if (m_logger.is_enabled(trace_level::info))
             {
-                m_logger.log(trace_level::info, std::string("no callback found for id: ").append(id));
+                m_logger.log(trace_level::info, std::string("no callback found for id: ").append(completion->invocation_id));
             }
-            return false;
         }
 
         return true;

--- a/src/signalrclient/logger.cpp
+++ b/src/signalrclient/logger.cpp
@@ -24,7 +24,12 @@ namespace signalr
 
     void logger::log(trace_level level, const std::string& entry) const
     {
-        if ((level & m_trace_level) != trace_level::none && m_log_writer)
+        log(level, entry.data(), entry.length());
+    }
+
+    void logger::log(trace_level level, const char* entry, size_t entry_count) const
+    {
+        if (level >= m_trace_level && m_log_writer)
         {
             try
             {
@@ -48,11 +53,12 @@ namespace signalr
                 snprintf(timeString + sizeof(timeString) - 5, 5, "%03dZ", (int)milliseconds.count());
 
                 auto trace_level = translate_trace_level(level);
-                assert(trace_level.length() <= 12);
+                assert(trace_level.length() <= 9);
 
                 std::stringstream os;
                 os << timeString << " ["
-                    << std::left << std::setw(12) << trace_level << "] "<< entry << std::endl;
+                    << std::left << std::setw(9) << trace_level << "] ";
+                os.write(entry, (std::streamsize)entry_count) << std::endl;
                 m_log_writer->write(os.str());
             }
             catch (const std::exception &e)
@@ -71,20 +77,20 @@ namespace signalr
     {
         switch (trace_level)
         {
-        case signalr::trace_level::messages:
-            return "message";
-        case signalr::trace_level::state_changes:
-            return "state change";
-        case signalr::trace_level::events:
-            return "event";
-        case signalr::trace_level::errors:
-            return "error";
+        case signalr::trace_level::verbose:
+            return "verbose";
+        case signalr::trace_level::debug:
+            return "debug";
         case signalr::trace_level::info:
             return "info";
+        case signalr::trace_level::warning:
+            return "warning";
+        case signalr::trace_level::error:
+            return "error";
+        case signalr::trace_level::critical:
+            return "critical";
         case signalr::trace_level::none:
             return "none";
-        case signalr::trace_level::all:
-            return "all";
         default:
             assert(false);
             return "(unknown)";

--- a/src/signalrclient/logger.cpp
+++ b/src/signalrclient/logger.cpp
@@ -52,12 +52,11 @@ namespace signalr
                 // 5 = 3 digits of millisecond precision + 'Z' + null character ending
                 snprintf(timeString + sizeof(timeString) - 5, 5, "%03dZ", (int)milliseconds.count());
 
-                auto trace_level = translate_trace_level(level);
-                assert(trace_level.length() <= 9);
-
                 std::stringstream os;
-                os << timeString << " ["
-                    << std::left << std::setw(9) << trace_level << "] ";
+                os << timeString;
+
+                write_trace_level(level, os);
+
                 os.write(entry, (std::streamsize)entry_count) << std::endl;
                 m_log_writer->write(os.str());
             }
@@ -73,27 +72,35 @@ namespace signalr
         }
     }
 
-    std::string logger::translate_trace_level(trace_level trace_level)
+    void logger::write_trace_level(trace_level trace_level, std::ostream& stream)
     {
         switch (trace_level)
         {
         case signalr::trace_level::verbose:
-            return "verbose";
+            stream << " [verbose  ] ";
+            break;
         case signalr::trace_level::debug:
-            return "debug";
+            stream << " [debug    ] ";
+            break;
         case signalr::trace_level::info:
-            return "info";
+            stream << " [info     ] ";
+            break;
         case signalr::trace_level::warning:
-            return "warning";
+            stream << " [warning  ] ";
+            break;
         case signalr::trace_level::error:
-            return "error";
+            stream << " [error    ] ";
+            break;
         case signalr::trace_level::critical:
-            return "critical";
+            stream << " [critical ] ";
+            break;
         case signalr::trace_level::none:
-            return "none";
+            stream << " [none     ] ";
+            break;
         default:
             assert(false);
-            return "(unknown)";
+            stream << " [(unknown)] ";
+            break;
         }
     }
 }

--- a/src/signalrclient/logger.h
+++ b/src/signalrclient/logger.h
@@ -36,6 +36,6 @@ namespace signalr
         std::shared_ptr<log_writer> m_log_writer;
         trace_level m_trace_level;
 
-        static std::string translate_trace_level(trace_level trace_level);
+        static void write_trace_level(trace_level trace_level, std::ostream& stream);
     };
 }

--- a/src/signalrclient/logger.h
+++ b/src/signalrclient/logger.h
@@ -15,7 +15,21 @@ namespace signalr
     public:
         logger(const std::shared_ptr<log_writer>& log_writer, trace_level trace_level) noexcept;
 
+        void log(trace_level level, const char* entry, size_t entry_count) const;
+
+        // TODO: variadic 'const char*' overload to avoid std::string allocations
         void log(trace_level level, const std::string& entry) const;
+
+        template <size_t N>
+        void log(trace_level level, const char (&entry)[N]) const
+        {
+            log(level, entry, N - 1);
+        }
+
+        bool is_enabled(trace_level level) const
+        {
+            return level >= m_trace_level;
+        }
 
     private:
         std::shared_ptr<log_writer> m_log_writer;

--- a/src/signalrclient/logger.h
+++ b/src/signalrclient/logger.h
@@ -23,6 +23,7 @@ namespace signalr
         template <size_t N>
         void log(trace_level level, const char (&entry)[N]) const
         {
+            // remove '\0'
             log(level, entry, N - 1);
         }
 

--- a/src/signalrclient/websocket_transport.cpp
+++ b/src/signalrclient/websocket_transport.cpp
@@ -81,15 +81,15 @@ namespace signalr
                     catch (const std::exception & e)
                     {
                         logger.log(
-                            trace_level::errors,
+                            trace_level::error,
                             std::string("[websocket transport] error receiving response from websocket: ")
                             .append(e.what()));
                     }
                     catch (...)
                     {
                         logger.log(
-                            trace_level::errors,
-                            std::string("[websocket transport] unknown error occurred when receiving response from websocket"));
+                            trace_level::error,
+                            "[websocket transport] unknown error occurred when receiving response from websocket");
 
                         exception = std::make_exception_ptr(signalr_exception("unknown error"));
                     }
@@ -194,7 +194,7 @@ namespace signalr
                     catch (const std::exception & e)
                     {
                         transport->m_logger.log(
-                            trace_level::errors,
+                            trace_level::error,
                             std::string("[websocket transport] exception when connecting to the server: ")
                             .append(e.what()));
 
@@ -242,7 +242,7 @@ namespace signalr
                 catch (const std::exception & e)
                 {
                     logger.log(
-                        trace_level::errors,
+                        trace_level::error,
                         std::string("[websocket transport] exception when closing websocket: ")
                         .append(e.what()));
 

--- a/test/signalrclienttests/hub_connection_tests.cpp
+++ b/test/signalrclienttests/hub_connection_tests.cpp
@@ -537,7 +537,7 @@ TEST(stop, connection_stopped_when_going_out_of_scope)
     // The underlying connection_impl will be destroyed when the last reference to shared_ptr holding is released. This can happen
     // on a different thread in which case the dtor will be invoked on a different thread so we need to wait for this
     // to happen and if it does not the test will fail. There is nothing we can block on.
-    for (int wait_time_ms = 5; wait_time_ms < 6000 && memory_writer->get_log_entries().size() < 4; wait_time_ms <<= 1)
+    for (int wait_time_ms = 5; wait_time_ms < 6000 && memory_writer->get_log_entries().size() < 6; wait_time_ms <<= 1)
     {
         std::this_thread::sleep_for(std::chrono::milliseconds(wait_time_ms));
     }

--- a/test/signalrclienttests/logger_tests.cpp
+++ b/test/signalrclienttests/logger_tests.cpp
@@ -14,59 +14,43 @@ TEST(logger_write, entry_added_if_trace_level_set)
 {
     std::shared_ptr<log_writer> writer(std::make_shared<memory_log_writer>());
 
-    logger l(writer, trace_level::messages);
-    l.log(trace_level::messages, "message");
+    logger l(writer, trace_level::info);
+    l.log(trace_level::info, "message");
 
     auto log_entries = std::dynamic_pointer_cast<memory_log_writer>(writer)->get_log_entries();
 
     ASSERT_EQ(1U, log_entries.size());
 }
 
-TEST(logger_write, entry_not_added_if_trace_level_not_set)
+TEST(logger_write, entry_not_added_if_trace_level_not_high_enough)
 {
     std::shared_ptr<log_writer> writer(std::make_shared<memory_log_writer>());
 
-    logger l(writer, trace_level::messages);
-    l.log(trace_level::events, "event");
+    logger l(writer, trace_level::info);
+    l.log(trace_level::debug, "event");
 
     auto log_entries = std::dynamic_pointer_cast<memory_log_writer>(writer)->get_log_entries();
 
     ASSERT_TRUE(log_entries.empty());
 }
 
-TEST(logger_write, entries_added_for_combined_trace_level)
-{
-    std::shared_ptr<log_writer> writer(std::make_shared<memory_log_writer>());
-
-    logger l(writer, trace_level::messages | trace_level::state_changes | trace_level::events | trace_level::errors | trace_level::info);
-    l.log(trace_level::messages, "message");
-    l.log(trace_level::events, "event");
-    l.log(trace_level::state_changes, "state_change");
-    l.log(trace_level::errors, "error");
-    l.log(trace_level::info, "info");
-
-    auto log_entries = std::dynamic_pointer_cast<memory_log_writer>(writer)->get_log_entries();
-
-    ASSERT_EQ(5U, log_entries.size());
-}
-
 TEST(logger_write, entries_formatted_correctly)
 {
     std::shared_ptr<log_writer> writer(std::make_shared<memory_log_writer>());
 
-    logger l(writer, trace_level::all);
-    l.log(trace_level::messages, "message");
+    logger l(writer, trace_level::verbose);
+    l.log(trace_level::info, "message");
 
     auto log_entries = std::dynamic_pointer_cast<memory_log_writer>(writer)->get_log_entries();
     ASSERT_FALSE(log_entries.empty());
 
     auto entry = log_entries[0];
 
-    //0000-0-00T00:00:00.000Z [message     ] message\n
-    std::regex r{ "[\\d]{4}-[\\d]{2}-[\\d]{2}T[\\d]{2}:[\\d]{2}:[\\d]{2}.[\\d]{3}Z \\[message     \\] message\\n" };
+    //0000-0-00T00:00:00.000Z [info     ] message\n
+    std::regex r{ "[\\d]{4}-[\\d]{2}-[\\d]{2}T[\\d]{2}:[\\d]{2}:[\\d]{2}.[\\d]{3}Z \\[info     \\] message\\n" };
     ASSERT_TRUE(std::regex_match(entry, r));
 
-    auto expected_message = std::string("[message     ] message\n");
+    auto expected_message = std::string("[info     ] message\n");
     auto pos = entry.find(expected_message);
     ASSERT_EQ(expected_message.size(), entry.size() - pos);
 }

--- a/test/signalrclienttests/test_utils.cpp
+++ b/test/signalrclienttests/test_utils.cpp
@@ -17,6 +17,18 @@ std::string remove_date_from_log_entry(const std::string &log_entry)
     return log_entry.substr(date_end_index + 1);
 }
 
+bool has_log_entry(const std::string& log_entry, const std::vector<std::string>& logs)
+{
+    for (auto& log : logs)
+    {
+        if (remove_date_from_log_entry(log) == log_entry)
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
 std::unique_ptr<http_client> create_test_http_client()
 {
     return std::unique_ptr<test_http_client>(new test_http_client([](const std::string & url, http_request request)

--- a/test/signalrclienttests/test_utils.h
+++ b/test/signalrclienttests/test_utils.h
@@ -9,6 +9,7 @@
 #include <future>
 
 std::string remove_date_from_log_entry(const std::string &log_entry);
+bool has_log_entry(const std::string& log_entry, const std::vector<std::string>& logs);
 
 std::unique_ptr<signalr::http_client> create_test_http_client();
 std::string create_uri();

--- a/test/signalrclienttests/websocket_transport_tests.cpp
+++ b/test/signalrclienttests/websocket_transport_tests.cpp
@@ -43,7 +43,7 @@ TEST(websocket_transport_connect, connect_connects_and_starts_receive_loop)
     ASSERT_FALSE(log_entries.empty());
 
     auto entry = remove_date_from_log_entry(log_entries[0]);
-    ASSERT_EQ("[info        ] [websocket transport] connecting to: ws://fakeuri.org/connect?param=42\n", entry);
+    ASSERT_EQ("[info     ] [websocket transport] connecting to: ws://fakeuri.org/connect?param=42\n", entry);
 }
 
 TEST(websocket_transport_connect, connect_propagates_exceptions)
@@ -81,7 +81,7 @@ TEST(websocket_transport_connect, connect_logs_exceptions)
     });
 
     std::shared_ptr<log_writer> writer(std::make_shared<memory_log_writer>());
-    auto ws_transport = websocket_transport::create([&](const signalr_client_config&){ return client; }, signalr_client_config{}, logger(writer, trace_level::errors));
+    auto ws_transport = websocket_transport::create([&](const signalr_client_config&){ return client; }, signalr_client_config{}, logger(writer, trace_level::error));
 
     auto mre = manual_reset_event<void>();
     ws_transport->start("ws://fakeuri.org", [&mre](std::exception_ptr exception)
@@ -101,7 +101,7 @@ TEST(websocket_transport_connect, connect_logs_exceptions)
     auto entry = remove_date_from_log_entry(log_entries[0]);
 
     ASSERT_EQ(
-        "[error       ] [websocket transport] exception when connecting to the server: connecting failed\n",
+        "[error    ] [websocket transport] exception when connecting to the server: connecting failed\n",
         entry);
 }
 
@@ -261,7 +261,7 @@ TEST(websocket_transport_disconnect, disconnect_logs_exceptions)
 
     std::shared_ptr<log_writer> writer(std::make_shared<memory_log_writer>());
 
-    auto ws_transport = websocket_transport::create([&](const signalr_client_config&){ return client; }, signalr_client_config{}, logger(writer, trace_level::errors));
+    auto ws_transport = websocket_transport::create([&](const signalr_client_config&){ return client; }, signalr_client_config{}, logger(writer, trace_level::error));
 
     auto mre = manual_reset_event<void>();
     ws_transport->start("ws://url", [&mre](std::exception_ptr exception)
@@ -292,7 +292,7 @@ TEST(websocket_transport_disconnect, disconnect_logs_exceptions)
     ASSERT_NE(std::find_if(log_entries.begin(), log_entries.end(), [](const std::string& entry)
         {
             return remove_date_from_log_entry(entry) ==
-                "[error       ] [websocket transport] exception when closing websocket: connection closing failed\n";
+                "[error    ] [websocket transport] exception when closing websocket: connection closing failed\n";
         }),
         log_entries.end());
 }
@@ -370,8 +370,8 @@ TEST(websocket_transport_receive_loop, receive_loop_logs_std_exception)
 {
     receive_loop_logs_exception_runner(
         std::runtime_error("exception"),
-        "[error       ] [websocket transport] error receiving response from websocket: exception\n",
-        trace_level::errors);
+        "[error    ] [websocket transport] error receiving response from websocket: exception\n",
+        trace_level::error);
 }
 
 template<typename T>


### PR DESCRIPTION
* Changed log levels to follow what we did in AspNetCore
* Added new overload for internal logger implementation to avoid unneeded allocations
```
template <size_t N>
void log(trace_level level, const char (&entry)[N]) const
```
* Added `is_enabled` checks to all currently allocating log calls (those that use `std::string` and `append`)
* Write directly to stream instead of making a temporary string for trace level string