### PR TITLE
Rename project to microsoft-signalr and add find_package cmake support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ if(DEFINED ENV{VCPKG_ROOT} AND NOT DEFINED CMAKE_TOOLCHAIN_FILE)
   set(CMAKE_TOOLCHAIN_FILE "$ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake")
 endif()
 
-project (signalrclient)
+project (microsoft-signalr)
 
 include(CTest)
 

--- a/README.md
+++ b/README.md
@@ -110,11 +110,8 @@ stop_task.get_future().get();
 cmake_minimum_required (VERSION 3.5)
 project (signalrclient-sample)
 
-find_path(SIGNALR_INCLUDE_DIR signalrclient/hub_connection.h)
-include_directories(${SIGNALR_INCLUDE_DIR})
-
-find_library(SIGNALR_LIBRARY NAMES signalrclient PATHS {SIGNALR_INCLUDE_DIR} REQUIRED)
-link_libraries(${SIGNALR_LIBRARY})
+find_package(microsoft-signalr REQUIRED)
+link_libraries(microsoft-signalr::microsoft-signalr)
 
 add_executable (sample sample.cpp)
 ```

--- a/samples/HubConnectionSample/CMakeLists.txt
+++ b/samples/HubConnectionSample/CMakeLists.txt
@@ -7,4 +7,4 @@ include_directories(
 
 add_executable (HubConnectionSample ${SOURCES})
 
-target_link_libraries(HubConnectionSample signalrclient)
+target_link_libraries(HubConnectionSample microsoft-signalr)

--- a/src/signalrclient/CMakeLists.txt
+++ b/src/signalrclient/CMakeLists.txt
@@ -90,21 +90,23 @@ endif() # USE_CPPRESTSDK
 include(GNUInstallDirs)
 
 install(TARGETS microsoft-signalr
+  # Creates the microsoft-signalr-targets.cmake file which allows find_package() to work
   EXPORT microsoft-signalr-targets
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
 
-configure_file(cmake/microsoft-signalr-config.in.cmake "${CMAKE_CURRENT_BINARY_DIR}/microsoft-signalr-config.cmake" @ONLY)
+# Create the microsoft-signalr-config.cmake with resolved values for variables used to build
+configure_file(microsoft-signalr-config.in.cmake "${CMAKE_CURRENT_BINARY_DIR}/microsoft-signalr-config.cmake")
 
 install(
   FILES ${CMAKE_CURRENT_BINARY_DIR}/microsoft-signalr-config.cmake
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/microsoft-signalr/cmake
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/share/microsoft-signalr
 )
 
 install(EXPORT microsoft-signalr-targets
   FILE microsoft-signalr-targets.cmake
   NAMESPACE microsoft-signalr::
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/microsoft-signalr/cmake
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/share/microsoft-signalr
 )

--- a/src/signalrclient/CMakeLists.txt
+++ b/src/signalrclient/CMakeLists.txt
@@ -98,7 +98,7 @@ install(TARGETS microsoft-signalr
 )
 
 # Create the microsoft-signalr-config.cmake with resolved values for variables used to build
-configure_file(microsoft-signalr-config.in.cmake "${CMAKE_CURRENT_BINARY_DIR}/microsoft-signalr-config.cmake")
+configure_file(microsoft-signalr-config.in.cmake "${CMAKE_CURRENT_BINARY_DIR}/microsoft-signalr-config.cmake" @ONLY)
 
 install(
   FILES ${CMAKE_CURRENT_BINARY_DIR}/microsoft-signalr-config.cmake

--- a/src/signalrclient/CMakeLists.txt
+++ b/src/signalrclient/CMakeLists.txt
@@ -87,8 +87,6 @@ else()
   endif()
 endif() # USE_CPPRESTSDK
 
-configure_file(cmake/microsoft-signalr-config.in.cmake "${CMAKE_CURRENT_BINARY_DIR}/microsoft-signalr-config.cmake" @ONLY)
-
 include(GNUInstallDirs)
 
 install(TARGETS microsoft-signalr
@@ -98,12 +96,15 @@ install(TARGETS microsoft-signalr
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
 
-export(TARGETS microsoft-signalr
-  NAMESPACE microsoft-signalr::
-  FILE ${CMAKE_CURRENT_BINARY_DIR}/microsoft-signalr-targets.cmake
+configure_file(cmake/microsoft-signalr-config.in.cmake "${CMAKE_CURRENT_BINARY_DIR}/microsoft-signalr-config.cmake" @ONLY)
+
+install(
+  FILES ${CMAKE_CURRENT_BINARY_DIR}/microsoft-signalr-config.cmake
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/microsoft-signalr/cmake
 )
 
 install(EXPORT microsoft-signalr-targets
+  FILE microsoft-signalr-targets.cmake
   NAMESPACE microsoft-signalr::
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/microsoft-signalr/cmake
 )

--- a/src/signalrclient/CMakeLists.txt
+++ b/src/signalrclient/CMakeLists.txt
@@ -28,16 +28,16 @@ include_directories(
   ../../third_party_code/cpprestsdk
 )
 
-add_library (signalrclient ${SOURCES})
+add_library (microsoft-signalr ${SOURCES})
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
     if(WERROR)
-        target_compile_options(signalrclient PRIVATE /WX)
+        target_compile_options(microsoft-signalr PRIVATE /WX)
     endif()
     if(WALL)
-        target_compile_options(signalrclient PRIVATE /Wall)
+        target_compile_options(microsoft-signalr PRIVATE /Wall)
     endif()
-    target_compile_options(signalrclient PRIVATE
+    target_compile_options(microsoft-signalr PRIVATE
         /wd4820 # padding added after data member
         /wd4514 # unreferenced inline function removed
         /wd5045 # compiler will insert Spectre mitigation if /Qspectre switch is added
@@ -51,37 +51,37 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
     )
 else()
     if(WERROR)
-        target_compile_options(signalrclient PRIVATE -Werror)
+        target_compile_options(microsoft-signalr PRIVATE -Werror)
     endif()
     if(WALL)
-        target_compile_options(signalrclient PRIVATE -Wall)
+        target_compile_options(microsoft-signalr PRIVATE -Wall)
     endif()
 
-    target_compile_options(signalrclient PRIVATE -Wextra -Wpedantic -Wno-unknown-pragmas)
+    target_compile_options(microsoft-signalr PRIVATE -Wextra -Wpedantic -Wno-unknown-pragmas)
 endif()
 
 if(INCLUDE_JSONCPP)
-  target_sources(signalrclient PRIVATE ../../third_party_code/jsoncpp/jsoncpp.cpp)
-  target_include_directories(signalrclient PRIVATE ../../third_party_code/jsoncpp)
+  target_sources(microsoft-signalr PRIVATE ../../third_party_code/jsoncpp/jsoncpp.cpp)
+  target_include_directories(microsoft-signalr PRIVATE ../../third_party_code/jsoncpp)
 else()
-  target_link_libraries(signalrclient PUBLIC ${JSONCPP_LIB})
+  target_link_libraries(microsoft-signalr PUBLIC ${JSONCPP_LIB})
 endif()
 
 if(NOT USE_CPPRESTSDK)
-  target_link_libraries(signalrclient)
+  target_link_libraries(microsoft-signalr)
 else()
   if(APPLE)
-    target_link_libraries(signalrclient
+    target_link_libraries(microsoft-signalr
       PUBLIC ${CPPREST_LIB}
       PRIVATE OpenSSL::SSL Boost::boost Boost::system Boost::chrono Boost::thread
     )
   elseif(NOT WIN32)
-    target_link_libraries(signalrclient
+    target_link_libraries(microsoft-signalr
       PUBLIC ${CPPREST_LIB} Boost::system
       PRIVATE OpenSSL::SSL
     )
   else()
-    target_link_libraries(signalrclient
+    target_link_libraries(microsoft-signalr
       PUBLIC ${CPPREST_LIB}
     )
   endif()
@@ -89,8 +89,19 @@ endif() # USE_CPPRESTSDK
 
 include(GNUInstallDirs)
 
-install(TARGETS signalrclient
+install(TARGETS microsoft-signalr
+  EXPORT microsoft-signalr-config
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+
+export(TARGETS microsoft-signalr
+  NAMESPACE microsoft-signalr::
+  FILE ${CMAKE_CURRENT_BINARY_DIR}/microsoft-signalr-config.cmake
+)
+
+install(EXPORT microsoft-signalr-config
+  NAMESPACE microsoft-signalr::
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/microsoft-signalr/cmake
 )

--- a/src/signalrclient/CMakeLists.txt
+++ b/src/signalrclient/CMakeLists.txt
@@ -87,10 +87,12 @@ else()
   endif()
 endif() # USE_CPPRESTSDK
 
+configure_file(cmake/microsoft-signalr-config.in.cmake "${CMAKE_CURRENT_BINARY_DIR}/microsoft-signalr-config.cmake" @ONLY)
+
 include(GNUInstallDirs)
 
 install(TARGETS microsoft-signalr
-  EXPORT microsoft-signalr-config
+  EXPORT microsoft-signalr-targets
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
@@ -98,10 +100,10 @@ install(TARGETS microsoft-signalr
 
 export(TARGETS microsoft-signalr
   NAMESPACE microsoft-signalr::
-  FILE ${CMAKE_CURRENT_BINARY_DIR}/microsoft-signalr-config.cmake
+  FILE ${CMAKE_CURRENT_BINARY_DIR}/microsoft-signalr-targets.cmake
 )
 
-install(EXPORT microsoft-signalr-config
+install(EXPORT microsoft-signalr-targets
   NAMESPACE microsoft-signalr::
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/microsoft-signalr/cmake
 )

--- a/src/signalrclient/cmake/microsoft-signalr-config.in.cmake
+++ b/src/signalrclient/cmake/microsoft-signalr-config.in.cmake
@@ -1,0 +1,5 @@
+if(@USE_CPPRESTSDK@)
+  find_dependency(cpprestsdk)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/microsoft-signalr-targets.cmake")

--- a/src/signalrclient/microsoft-signalr-config.in.cmake
+++ b/src/signalrclient/microsoft-signalr-config.in.cmake
@@ -4,8 +4,8 @@ if(@USE_CPPRESTSDK@)
   find_dependency(cpprestsdk)
 endif()
 
-if(@INCLUDE_JSONCPP@)
-  find_dependency(${JSONCPP_LIB})
+if(NOT @INCLUDE_JSONCPP@)
+  find_dependency(@${JSONCPP_LIB}@)
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/microsoft-signalr-targets.cmake")

--- a/src/signalrclient/microsoft-signalr-config.in.cmake
+++ b/src/signalrclient/microsoft-signalr-config.in.cmake
@@ -1,5 +1,11 @@
+include(CMakeFindDependencyMacro)
+
 if(@USE_CPPRESTSDK@)
   find_dependency(cpprestsdk)
+endif()
+
+if(@INCLUDE_JSONCPP@)
+  find_dependency(${JSONCPP_LIB})
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/microsoft-signalr-targets.cmake")

--- a/src/signalrclient/microsoft-signalr-config.in.cmake
+++ b/src/signalrclient/microsoft-signalr-config.in.cmake
@@ -5,7 +5,7 @@ if(@USE_CPPRESTSDK@)
 endif()
 
 if(NOT @INCLUDE_JSONCPP@)
-  find_dependency(@${JSONCPP_LIB}@)
+  find_dependency(@JSONCPP_LIB@)
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/microsoft-signalr-targets.cmake")

--- a/test/signalrclienttests/CMakeLists.txt
+++ b/test/signalrclienttests/CMakeLists.txt
@@ -25,5 +25,5 @@ include_directories(
 
 add_executable (signalrclienttests ${SOURCES})
 
-target_link_libraries(signalrclienttests gtest signalrclient)
+target_link_libraries(signalrclienttests gtest microsoft-signalr)
 add_test(NAME signalrclienttests COMMAND signalrclienttests)


### PR DESCRIPTION
If you want to try this out, first run `vcpkg.exe remove microsoft-signalr:x64-windows`, then update the local portfile.cmake for microsoft-signalr as shown below, then run `vcpkg.exe install microsoft-signalr:x64-windows

When we update the portfile on vcpkg we'll need to do the below:
```
vcpkg_from_github(
    OUT_SOURCE_PATH SOURCE_PATH
    REPO aspnet/SignalR-Client-Cpp
    REF ee5926183f16bea153bcb4ae5a9370884a9d07c1
    SHA512 d65a354bff1c9d29f48046844d167fbded6bf35b5c9decadcda3ace8df79b26e51183f788b695ae5aed0afb4084b917f0a5a474a671757df6c688fe05172b6fb
    HEAD_REF main
)

vcpkg_check_features(
    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
    FEATURES
        cpprestsdk USE_CPPRESTSDK
)

if("cpprestsdk" IN_LIST FEATURES AND VCPKG_TARGET_IS_UWP)
    message(FATAL_ERROR "microsoft-signalr[cpprestsdk] is not supported on UWP, use microsoft-signalr[core] instead")
endif()

vcpkg_configure_cmake(
    SOURCE_PATH ${SOURCE_PATH}
    PREFER_NINJA
    OPTIONS
        -DBUILD_TESTING=OFF
        ${FEATURE_OPTIONS}
        -DWALL=OFF
)

vcpkg_install_cmake()
vcpkg_fixup_cmake_targets(CONFIG_PATH lib/share/microsoft-signalr)
file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/lib/share ${CURRENT_PACKAGES_DIR}/lib/share)
file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)

file(INSTALL ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
file(COPY ${SOURCE_PATH}/third-party-notices.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})

vcpkg_copy_pdbs()
```

And your apps CMakeLists.txt (when using `CMAKE_TOOLCHAIN_FILE`):
```
find_package(microsoft-signalr REQUIRED)
link_libraries(microsoft-signalr::microsoft-signalr)
```
No need to add `include_directories`, they should work automatically.