### PR TITLE
Compile test project with source files instead of library reference

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,10 +19,6 @@ else()
   set(EXTRA_FLAGS "-DSIGNALRCLIENT_EXPORTS")
 endif()
 
-if(USE_CPPRESTSDK)
-  string(APPEND EXTRA_FLAGS " -DUSE_CPPRESTSDK")
-endif()
-
 if(INJECT_HEADER_AFTER_STDAFX)
   string(APPEND EXTRA_FLAGS " -DINJECT_HEADER_AFTER_STDAFX=${INJECT_HEADER_AFTER_STDAFX}")
 endif()
@@ -44,10 +40,6 @@ if(NOT INCLUDE_JSONCPP)
 endif()
 
 include_directories (include)
-
-# TODO: We shouldn't use this, it makes the dll/lib export all symbols
-# We need this for testing, but we might just add all the files to the test project manually
-set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
 if(USE_CPPRESTSDK)
   if(NOT WIN32)

--- a/include/signalrclient/signalr_value.h
+++ b/include/signalrclient/signalr_value.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "_exports.h"
 #include <string>
 #include <vector>
 #include <map>
@@ -33,152 +34,152 @@ namespace signalr
         /**
          * Create an object representing a value_type::null value.
          */
-        value();
+        SIGNALRCLIENT_API value();
 
         /**
          * Create an object representing a value_type::null value.
          */
-        value(std::nullptr_t);
+        SIGNALRCLIENT_API value(std::nullptr_t);
 
         /**
          * Create an object representing a default value for the given value_type.
          */
-        value(value_type t);
+        SIGNALRCLIENT_API value(value_type t);
 
         /**
          * Create an object representing a value_type::boolean with the given bool value.
          */
-        value(bool val);
+        SIGNALRCLIENT_API value(bool val);
 
         /**
          * Create an object representing a value_type::float64 with the given double value.
          */
-        value(double val);
+        SIGNALRCLIENT_API value(double val);
 
         /**
          * Create an object representing a value_type::string with the given string value.
          */
-        value(const std::string& val);
+        SIGNALRCLIENT_API value(const std::string& val);
 
         /**
          * Create an object representing a value_type::string with the given string value.
          */
-        value(std::string&& val);
+        SIGNALRCLIENT_API value(std::string&& val);
 
         /**
          * Create an object representing a value_type::string with the given string value.
          */
-        value(const char* val);
+        SIGNALRCLIENT_API value(const char* val);
 
         /**
          * Create an object representing a value_type::string with the given string value.
          */
-        value(const char* val, size_t length);
+        SIGNALRCLIENT_API value(const char* val, size_t length);
 
         /**
          * Create an object representing a value_type::array with the given vector of value's.
          */
-        value(const std::vector<value>& val);
+        SIGNALRCLIENT_API value(const std::vector<value>& val);
 
         /**
          * Create an object representing a value_type::array with the given vector of value's.
          */
-        value(std::vector<value>&& val);
+        SIGNALRCLIENT_API value(std::vector<value>&& val);
 
         /**
          * Create an object representing a value_type::map with the given map of string-value's.
          */
-        value(const std::map<std::string, value>& map);
+        SIGNALRCLIENT_API value(const std::map<std::string, value>& map);
 
         /**
          * Create an object representing a value_type::map with the given map of string-value's.
          */
-        value(std::map<std::string, value>&& map);
+        SIGNALRCLIENT_API value(std::map<std::string, value>&& map);
 
         /**
          * Copies an existing value.
          */
-        value(const value& rhs);
+        SIGNALRCLIENT_API value(const value& rhs);
 
         /**
          * Moves an existing value.
          */
-        value(value&& rhs) noexcept;
+        SIGNALRCLIENT_API value(value&& rhs) noexcept;
 
         /**
          * Cleans up the resources associated with the value.
          */
-        ~value();
+        SIGNALRCLIENT_API ~value();
 
         /**
          * Copies an existing value.
          */
-        value& operator=(const value& rhs);
+        SIGNALRCLIENT_API value& operator=(const value& rhs);
 
         /**
          * Moves an existing value.
          */
-        value& operator=(value&& rhs) noexcept;
+        SIGNALRCLIENT_API value& operator=(value&& rhs) noexcept;
 
         /**
          * True if the object stored is a Key-Value pair.
          */
-        bool is_map() const;
+        SIGNALRCLIENT_API bool is_map() const;
 
         /**
          * True if the object stored is a double.
          */
-        bool is_double() const;
+        SIGNALRCLIENT_API bool is_double() const;
 
         /**
          * True if the object stored is a string.
          */
-        bool is_string() const;
+        SIGNALRCLIENT_API bool is_string() const;
 
         /**
          * True if the object stored is empty.
          */
-        bool is_null() const;
+        SIGNALRCLIENT_API bool is_null() const;
 
         /**
          * True if the object stored is an array of signalr::value's.
          */
-        bool is_array() const;
+        SIGNALRCLIENT_API bool is_array() const;
 
         /**
          * True if the object stored is a bool.
          */
-        bool is_bool() const;
+        SIGNALRCLIENT_API bool is_bool() const;
 
         /**
          * Returns the stored object as a double. This will throw if the underlying object is not a signalr::type::float64.
          */
-        double as_double() const;
+        SIGNALRCLIENT_API double as_double() const;
 
         /**
          * Returns the stored object as a bool. This will throw if the underlying object is not a signalr::type::boolean.
          */
-        bool as_bool() const;
+        SIGNALRCLIENT_API bool as_bool() const;
 
         /**
          * Returns the stored object as a string. This will throw if the underlying object is not a signalr::type::string.
          */
-        const std::string& as_string() const;
+        SIGNALRCLIENT_API const std::string& as_string() const;
 
         /**
          * Returns the stored object as an array of signalr::value's. This will throw if the underlying object is not a signalr::type::array.
          */
-        const std::vector<value>& as_array() const;
+        SIGNALRCLIENT_API const std::vector<value>& as_array() const;
 
         /**
          * Returns the stored object as a map of property name to signalr::value. This will throw if the underlying object is not a signalr::type::map.
          */
-        const std::map<std::string, value>& as_map() const;
+        SIGNALRCLIENT_API const std::map<std::string, value>& as_map() const;
 
         /**
          * Returns the signalr::type that represents the stored object.
          */
-        value_type type() const;
+        SIGNALRCLIENT_API value_type type() const;
 
     private:
         value_type mType;

--- a/src/signalrclient/CMakeLists.txt
+++ b/src/signalrclient/CMakeLists.txt
@@ -70,6 +70,8 @@ endif()
 if(NOT USE_CPPRESTSDK)
   target_link_libraries(microsoft-signalr)
 else()
+  set_target_properties(microsoft-signalr PROPERTIES COMPILE_FLAGS "-DUSE_CPPRESTSDK" )
+
   if(APPLE)
     target_link_libraries(microsoft-signalr
       PUBLIC ${CPPREST_LIB}

--- a/test/signalrclienttests/CMakeLists.txt
+++ b/test/signalrclienttests/CMakeLists.txt
@@ -1,5 +1,3 @@
-
-
 set (SOURCES
   callback_manager_tests.cpp
   case_insensitive_comparison_utils_tests.cpp
@@ -21,9 +19,47 @@ set (SOURCES
 )
 
 include_directories(
-    ../../src/signalrclient)
+  ../../src/signalrclient
+)
+
+# include main library sources for "internals visible to"
+list (APPEND SOURCES
+  ../../src/signalrclient/callback_manager.cpp
+  ../../src/signalrclient/connection.cpp
+  ../../src/signalrclient/connection_impl.cpp
+  ../../src/signalrclient/default_http_client.cpp
+  ../../src/signalrclient/default_websocket_client.cpp
+  ../../src/signalrclient/handshake_protocol.cpp
+  ../../src/signalrclient/hub_connection.cpp
+  ../../src/signalrclient/hub_connection_builder.cpp
+  ../../src/signalrclient/hub_connection_impl.cpp
+  ../../src/signalrclient/json_helpers.cpp
+  ../../src/signalrclient/json_hub_protocol.cpp
+  ../../src/signalrclient/logger.cpp
+  ../../src/signalrclient/negotiate.cpp
+  ../../src/signalrclient/signalr_client_config.cpp
+  ../../src/signalrclient/signalr_value.cpp
+  ../../src/signalrclient/trace_log_writer.cpp
+  ../../src/signalrclient/transport.cpp
+  ../../src/signalrclient/transport_factory.cpp
+  ../../src/signalrclient/url_builder.cpp
+  ../../src/signalrclient/websocket_transport.cpp
+  ../../third_party_code/cpprestsdk/uri.cpp
+  ../../third_party_code/cpprestsdk/uri_builder.cpp
+)
+
+include_directories(
+  ../../third_party_code/cpprestsdk
+)
 
 add_executable (signalrclienttests ${SOURCES})
 
-target_link_libraries(signalrclienttests gtest microsoft-signalr)
+if(INCLUDE_JSONCPP)
+  target_sources(signalrclienttests PRIVATE ../../third_party_code/jsoncpp/jsoncpp.cpp)
+  target_include_directories(signalrclienttests PRIVATE ../../third_party_code/jsoncpp)
+else()
+  target_link_libraries(microsoft-signalr PUBLIC ${JSONCPP_LIB})
+endif()
+
+target_link_libraries(signalrclienttests gtest)
 add_test(NAME signalrclienttests COMMAND signalrclienttests)


### PR DESCRIPTION
Remove `CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS` which exposed all classes to user code and compile the test project with the main libraries source instead of with the library reference.