### PR TITLE
Update Mac machine to 10.15

### DIFF
--- a/.azure/default-build.yml
+++ b/.azure/default-build.yml
@@ -24,7 +24,7 @@ jobs:
     enableTelemetry: true
     pool:
       ${{ if eq(parameters.agentOs, 'macOS') }}:
-        vmImage: macOS-10.14
+        vmImage: macOS-10.15
       ${{ if eq(parameters.agentOs, 'Linux') }}:
         vmImage: ubuntu-16.04
       ${{ if eq(parameters.agentOs, 'Windows') }}:
@@ -40,9 +40,9 @@ jobs:
         cacheHitVar: CACHE_RESTORED
       displayName: Cache vcpkg packages
       condition: eq( '${{ parameters.useCppRestSDK }}', 'true' )
-  
+
     - ${{ parameters.beforeBuild }}
-  
+
     - task: CMake@1
       inputs:
         cmakeArgs: .. ${{ parameters.cMakeRunArgs }} -DCMAKE_TOOLCHAIN_FILE=../submodules/vcpkg/scripts/buildsystems/vcpkg.cmake -DCMAKE_BUILD_TYPE=${{ parameters.configuration }} -DUSE_CPPRESTSDK=${{ parameters.useCppRestSDK }}
@@ -67,7 +67,7 @@ jobs:
         displayName: Run tests
 
     - ${{ parameters.afterBuild }}
-  
+
     - task: PublishTestResults@2
       displayName: Publish test results
       condition: always()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,8 +47,6 @@ stages:
       jobName: Mac_Build_Test_With_CppRestSDK
       useCppRestSDK: true
       beforeBuild:
-      - script: brew install gcc
-        displayName: Install gcc
       - bash: "./submodules/vcpkg/bootstrap-vcpkg.sh"
         condition: ne(variables.CACHE_RESTORED, 'true')
         displayName: Bootstrap vcpkg

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,7 +47,7 @@ stages:
       jobName: Mac_Build_Test_With_CppRestSDK
       useCppRestSDK: true
       beforeBuild:
-      - bash: "./submodules/vcpkg/bootstrap-vcpkg.sh"
+      - bash: "./submodules/vcpkg/bootstrap-vcpkg.sh --allowAppleClang"
         condition: ne(variables.CACHE_RESTORED, 'true')
         displayName: Bootstrap vcpkg
       - bash: "./submodules/vcpkg/vcpkg install cpprestsdk"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -66,7 +66,7 @@ stages:
       - bash: "./submodules/vcpkg/vcpkg install cpprestsdk boost-system boost-chrono boost-thread --vcpkg-root ./submodules/vcpkg"
         condition: ne(variables.CACHE_RESTORED, 'true')
         displayName: vcpkg install dependencies
-      - bash: "sudo apt install valgrind"
+      - bash: "sudo apt-get update && sudo apt install valgrind"
         displayName: install valgrind
 
   - template: .azure/default-build.yml
@@ -75,7 +75,7 @@ stages:
       jobName: Linux_Build_Test
       useCppRestSDK: false
       beforeBuild:
-      - bash: "sudo apt install valgrind"
+      - bash: "sudo apt-get update && sudo apt install valgrind"
         displayName: install valgrind
 
   - template: .azure/default-build.yml


### PR DESCRIPTION
Gcc from brew has issues with Mac, so switching to bootstrapping vcpkg with clang, but clang can't build vcpkg on mac 10.14 so updating to 10.15. And 10.14 is going out of support in November looks like.