### PR TITLE
Fix build of http client

### DIFF
--- a/include/signalrclient/http_client.h
+++ b/include/signalrclient/http_client.h
@@ -8,6 +8,7 @@
 #include <functional>
 #include <map>
 #include <chrono>
+#include <exception>
 
 namespace signalr
 {


### PR DESCRIPTION
[aspnetcore issue](https://github.com/dotnet/aspnetcore/issues/34070)

Fixed build error with g++ 11.1.0 on Arch Linux.
Added `exception` header include to the `include/signalrclient/http_client.h`.