### PR TITLE
Add public cancellation_token and pass to http_client

### DIFF
--- a/include/signalrclient/cancellation_token.h
+++ b/include/signalrclient/cancellation_token.h
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#pragma once
+
+#include <memory>
+
+namespace signalr
+{
+    class cancellation_token_source;
+
+    class cancellation_token
+    {
+    public:
+        /**
+         * Register a callback to run when this token is canceled or destructed.
+         * If the token is already canceled, the callback will run immediately.
+         */
+        void register_callback(std::function<void()> callback);
+
+        /**
+         * Check if the token has been canceled already.
+         */
+        bool is_canceled() const;
+    private:
+        friend cancellation_token get_cancellation_token(std::weak_ptr<cancellation_token_source> s);
+
+        cancellation_token(std::weak_ptr<cancellation_token_source> parent)
+            : mParent(parent)
+        {
+        }
+
+        std::weak_ptr<cancellation_token_source> mParent;
+    };
+}

--- a/include/signalrclient/http_client.h
+++ b/include/signalrclient/http_client.h
@@ -8,6 +8,7 @@
 #include <functional>
 #include <map>
 #include <chrono>
+#include "cancellation_token.h"
 #include <exception>
 
 namespace signalr
@@ -62,7 +63,8 @@ namespace signalr
     class http_client
     {
     public:
-        virtual void send(const std::string& url, const http_request& request, std::function<void(const http_response&, std::exception_ptr)> callback) = 0;
+        virtual void send(const std::string& url, http_request& request,
+            std::function<void(const http_response&, std::exception_ptr)> callback, cancellation_token token) = 0;
 
         virtual ~http_client() {}
     };

--- a/src/signalrclient/CMakeLists.txt
+++ b/src/signalrclient/CMakeLists.txt
@@ -1,5 +1,6 @@
 set (SOURCES
   callback_manager.cpp
+  cancellation_token.cpp
   connection.cpp
   connection_impl.cpp
   default_http_client.cpp

--- a/src/signalrclient/CMakeLists.txt
+++ b/src/signalrclient/CMakeLists.txt
@@ -1,6 +1,7 @@
 set (SOURCES
   callback_manager.cpp
   cancellation_token.cpp
+  cancellation_token_source.cpp
   connection.cpp
   connection_impl.cpp
   default_http_client.cpp

--- a/src/signalrclient/cancellation_token.cpp
+++ b/src/signalrclient/cancellation_token.cpp
@@ -30,9 +30,4 @@ namespace signalr
         }
         return true;
     }
-
-    cancellation_token get_cancellation_token(std::weak_ptr<cancellation_token_source> s)
-    {
-        return cancellation_token(s);
-    }
 }

--- a/src/signalrclient/cancellation_token.cpp
+++ b/src/signalrclient/cancellation_token.cpp
@@ -1,0 +1,38 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include "stdafx.h"
+#include "cancellation_token_source.h"
+#include "signalrclient/cancellation_token.h"
+
+namespace signalr
+{
+    void cancellation_token::register_callback(std::function<void()> callback)
+    {
+        auto obj = mParent.lock();
+        if (obj)
+        {
+            obj->register_callback(callback);
+        }
+        else
+        {
+            callback();
+        }
+    }
+
+    bool cancellation_token::is_canceled() const
+    {
+        auto obj = mParent.lock();
+        if (obj)
+        {
+            return obj->is_canceled();
+        }
+        return true;
+    }
+
+    cancellation_token get_cancellation_token(std::weak_ptr<cancellation_token_source> s)
+    {
+        return cancellation_token(s);
+    }
+}

--- a/src/signalrclient/cancellation_token_source.cpp
+++ b/src/signalrclient/cancellation_token_source.cpp
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include "stdafx.h"
+#include "cancellation_token_source.h"
+
+namespace signalr
+{
+    const unsigned int cancellation_token_source::timeout_infinite = 0xFFFFFFFF;
+
+    cancellation_token get_cancellation_token(std::weak_ptr<cancellation_token_source> s)
+    {
+        return cancellation_token(s);
+    }
+}

--- a/src/signalrclient/cancellation_token_source.h
+++ b/src/signalrclient/cancellation_token_source.h
@@ -19,7 +19,7 @@ namespace signalr
     class cancellation_token_source
     {
     public:
-        static const unsigned int timeout_infinite = 0xFFFFFFFF;
+        static const unsigned int timeout_infinite;
 
         cancellation_token_source() noexcept
             : m_signaled(false)

--- a/src/signalrclient/cancellation_token_source.h
+++ b/src/signalrclient/cancellation_token_source.h
@@ -25,7 +25,7 @@ namespace signalr
             m_message += '\n';
         }
 
-        virtual char const* what() const
+        virtual char const* what() const noexcept
         {
             return m_message.c_str();
         }

--- a/src/signalrclient/cancellation_token_source.h
+++ b/src/signalrclient/cancellation_token_source.h
@@ -14,6 +14,10 @@ namespace signalr
 {
     class canceled_exception : public std::exception
     {
+        virtual char const* what() const noexcept
+        {
+            return "an operation was canceled";
+        }
     };
 
     class aggregate_exception : public std::exception
@@ -21,8 +25,11 @@ namespace signalr
     public:
         void add_exception(const std::exception& ex)
         {
+            if (!m_message.empty())
+            {
+                m_message += '\n';
+            }
             m_message += ex.what();
-            m_message += '\n';
         }
 
         virtual char const* what() const noexcept
@@ -45,8 +52,6 @@ namespace signalr
 
         cancellation_token_source(const cancellation_token_source&) = delete;
         cancellation_token_source& operator=(const cancellation_token_source&) = delete;
-
-        ~cancellation_token_source() {}
 
         void cancel()
         {

--- a/src/signalrclient/cancellation_token_source.h
+++ b/src/signalrclient/cancellation_token_source.h
@@ -8,6 +8,7 @@
 #include <condition_variable>
 #include <mutex>
 #include <vector>
+#include "signalrclient/cancellation_token.h"
 
 namespace signalr
 {
@@ -144,4 +145,6 @@ namespace signalr
         bool m_signaled;
         std::vector<std::function<void()>> m_callbacks;
     };
+
+    cancellation_token get_cancellation_token(std::weak_ptr<cancellation_token_source> s);
 }

--- a/src/signalrclient/cancellation_token_source.h
+++ b/src/signalrclient/cancellation_token_source.h
@@ -7,6 +7,7 @@
 #include <assert.h>
 #include <condition_variable>
 #include <mutex>
+#include <vector>
 
 namespace signalr
 {
@@ -14,50 +15,70 @@ namespace signalr
     {
     };
 
-    class cancellation_token
+    class cancellation_token_source
     {
     public:
         static const unsigned int timeout_infinite = 0xFFFFFFFF;
 
-        cancellation_token() noexcept
+        cancellation_token_source() noexcept
             : m_signaled(false)
         {
         }
 
-        cancellation_token(const cancellation_token&) = delete;
-        cancellation_token& operator=(const cancellation_token&) = delete;
+        cancellation_token_source(const cancellation_token_source&) = delete;
+        cancellation_token_source& operator=(const cancellation_token_source&) = delete;
 
-        ~cancellation_token()
+        ~cancellation_token_source()
         {
-            if (m_callback)
+            if (!m_callbacks.empty())
             {
-                m_callback();
+                for (auto& func : m_callbacks)
+                {
+                    try
+                    {
+                        func();
+                    }
+                    catch (...)
+                    {
+                        assert(false);
+                    }
+                }
             }
         }
 
         void cancel()
         {
-            std::function<void()> callback;
+            std::vector<std::function<void()>> callbacks;
             {
                 std::lock_guard<std::mutex> lock(m_lock);
                 m_signaled = true;
                 m_condition.notify_all();
-                callback = m_callback;
-                m_callback = nullptr;
+                callbacks = std::move(m_callbacks);
+                m_callbacks = std::vector<std::function<void()>>();
             } // unlock
 
-            if (callback)
+            if (!callbacks.empty())
             {
-                callback();
+                for (auto& func : callbacks)
+                {
+                    try
+                    {
+                        func();
+                    }
+                    catch (...)
+                    {
+                        assert(false);
+                    }
+                }
             }
         }
 
         void reset()
         {
             std::lock_guard<std::mutex> lock(m_lock);
-            assert(m_callback == nullptr);
+            assert(m_callbacks.empty());
             m_signaled = false;
-            m_callback = nullptr;
+            m_callbacks.clear();
         }
 
         bool is_canceled() const
@@ -68,7 +89,7 @@ namespace signalr
         unsigned int wait(unsigned int timeout)
         {
             std::unique_lock<std::mutex> lock(m_lock);
-            if (timeout == cancellation_token::timeout_infinite)
+            if (timeout == cancellation_token_source::timeout_infinite)
             {
                 m_condition.wait(lock, [this]() noexcept { return m_signaled; });
                 return 0;
@@ -79,13 +100,13 @@ namespace signalr
                 const auto status = m_condition.wait_for(lock, period, [this]() noexcept { return m_signaled; });
                 assert(status == m_signaled);
                 // Return 0 if the wait completed as a result of signaling the event. Otherwise, return timeout_infinite
-                return status ? 0 : cancellation_token::timeout_infinite;
+                return status ? 0 : cancellation_token_source::timeout_infinite;
             }
         }
 
         unsigned int wait()
         {
-            return wait(cancellation_token::timeout_infinite);
+            return wait(cancellation_token_source::timeout_infinite);
         }
 
         void throw_if_cancellation_requested() const
@@ -101,14 +122,13 @@ namespace signalr
             bool run_callback = false;
             {
                 std::lock_guard<std::mutex> lock(m_lock);
-                assert(m_callback == nullptr);
                 if (m_signaled)
                 {
                     run_callback = m_signaled;
                 }
                 else
                 {
-                    m_callback = callback;
+                    m_callbacks.push_back(callback);
                 }
             } // unlock
 
@@ -122,6 +142,6 @@ namespace signalr
         std::mutex m_lock;
         std::condition_variable m_condition;
         bool m_signaled;
-        std::function<void()> m_callback;
+        std::vector<std::function<void()>> m_callbacks;
     };
 }

--- a/src/signalrclient/connection_impl.cpp
+++ b/src/signalrclient/connection_impl.cpp
@@ -327,7 +327,7 @@ namespace signalr
                     return;
                 }
 
-                connection->start_transport(url, transport_started);
+                connection->start_transport(url, callback);
             });
     }
 

--- a/src/signalrclient/connection_impl.cpp
+++ b/src/signalrclient/connection_impl.cpp
@@ -35,7 +35,7 @@ namespace signalr
     connection_impl::connection_impl(const std::string& url, trace_level trace_level, const std::shared_ptr<log_writer>& log_writer,
         std::function<std::shared_ptr<http_client>(const signalr_client_config&)> http_client_factory, std::function<std::shared_ptr<websocket_client>(const signalr_client_config&)> websocket_factory, const bool skip_negotiation)
         : m_base_url(url), m_connection_state(connection_state::disconnected), m_logger(log_writer, trace_level), m_transport(nullptr), m_skip_negotiation(skip_negotiation),
-        m_message_received([](const std::string&) noexcept {}), m_disconnected([](std::exception_ptr) noexcept {}), m_disconnect_cts(std::make_shared<cancellation_token>())
+        m_message_received([](const std::string&) noexcept {}), m_disconnected([](std::exception_ptr) noexcept {}), m_disconnect_cts(std::make_shared<cancellation_token_source>())
     {
         if (http_client_factory != nullptr)
         {
@@ -327,8 +327,8 @@ namespace signalr
                     return;
                 }
 
-                connection->start_transport(url, callback);
-            });
+                connection->start_transport(url, transport_started);
+            }, get_cancellation_token(m_disconnect_cts));
     }
 
     void connection_impl::start_transport(const std::string& url, std::function<void(std::shared_ptr<transport>, std::exception_ptr)> transport_started)

--- a/src/signalrclient/connection_impl.cpp
+++ b/src/signalrclient/connection_impl.cpp
@@ -65,7 +65,18 @@ namespace signalr
             // Signaling the event is safe here. We are in the dtor so noone is using this instance. There might be some
             // outstanding threads that hold on to the connection via a weak pointer but they won't be able to acquire
             // the instance since it is being destroyed. Note that the event may actually be in non-signaled state here.
-            m_start_completed_event.cancel();
+            try
+            {
+                m_start_completed_event.cancel();
+            }
+            catch (const std::exception& ex)
+            {
+                if (m_logger.is_enabled(trace_level::warning))
+                {
+                    m_logger.log(trace_level::warning, std::string("start completed event threw an exception in the destructor: ")
+                        .append(ex.what()));
+                }
+            }
             completion_event completion;
             auto logger = m_logger;
             shutdown([completion, logger](std::exception_ptr exception) mutable
@@ -194,7 +205,18 @@ namespace signalr
 
                 connection->m_transport = nullptr;
                 connection->change_state(connection_state::disconnected);
-                connection->m_start_completed_event.cancel();
+                try
+                {
+                    connection->m_start_completed_event.cancel();
+                }
+                catch (const std::exception& ex)
+                {
+                    if (connection->m_logger.is_enabled(trace_level::warning))
+                    {
+                        connection->m_logger.log(trace_level::warning, std::string("start completed event threw an exception in start negotiate: ")
+                            .append(ex.what()));
+                    }
+                }
                 callback(std::current_exception());
                 return;
             }
@@ -213,7 +235,18 @@ namespace signalr
                 assert(false);
             }
 
-            connection->m_start_completed_event.cancel();
+            try
+            {
+                connection->m_start_completed_event.cancel();
+            }
+            catch (const std::exception& ex)
+            {
+                if (connection->m_logger.is_enabled(trace_level::warning))
+                {
+                    connection->m_logger.log(trace_level::warning, std::string("start completed event threw an exception in start negotiate: ")
+                        .append(ex.what()));
+                }
+            }
             callback(nullptr);
         };
 
@@ -552,7 +585,18 @@ namespace signalr
             const auto current_state = get_connection_state();
             if (current_state == connection_state::disconnected)
             {
-                m_disconnect_cts->cancel();
+                try
+                {
+                    m_disconnect_cts->cancel();
+                }
+                catch (const std::exception& ex)
+                {
+                    if (m_logger.is_enabled(trace_level::warning))
+                    {
+                        m_logger.log(trace_level::warning, std::string("disconnect event threw an exception in shutdown: ")
+                            .append(ex.what()));
+                    }
+                }
                 callback(m_stop_error);
                 return;
             }
@@ -567,7 +611,18 @@ namespace signalr
             }
 
             // we request a cancellation of the ongoing start (if any) and wait until it is canceled
-            m_disconnect_cts->cancel();
+            try
+            {
+                m_disconnect_cts->cancel();
+            }
+            catch (const std::exception& ex)
+            {
+                if (m_logger.is_enabled(trace_level::warning))
+                {
+                    m_logger.log(trace_level::warning, std::string("disconnect event threw an exception in shutdown: ")
+                        .append(ex.what()));
+                }
+            }
 
             while (m_start_completed_event.wait(60000) != 0)
             {

--- a/src/signalrclient/connection_impl.cpp
+++ b/src/signalrclient/connection_impl.cpp
@@ -17,7 +17,6 @@
 #include "signalrclient/websocket_client.h"
 #include "default_websocket_client.h"
 #include "signalr_default_scheduler.h"
-#include "signalrclient/cancellation_token.h"
 
 namespace signalr
 {

--- a/src/signalrclient/connection_impl.cpp
+++ b/src/signalrclient/connection_impl.cpp
@@ -17,6 +17,7 @@
 #include "signalrclient/websocket_client.h"
 #include "default_websocket_client.h"
 #include "signalr_default_scheduler.h"
+#include "signalrclient/cancellation_token.h"
 
 namespace signalr
 {

--- a/src/signalrclient/connection_impl.h
+++ b/src/signalrclient/connection_impl.h
@@ -13,7 +13,7 @@
 #include "transport_factory.h"
 #include "logger.h"
 #include "negotiation_response.h"
-#include "cancellation_token.h"
+#include "cancellation_token_source.h"
 
 namespace signalr
 {
@@ -63,9 +63,9 @@ namespace signalr
         std::function<void(std::exception_ptr)> m_disconnected;
         signalr_client_config m_signalr_client_config;
 
-        std::shared_ptr<cancellation_token> m_disconnect_cts;
+        std::shared_ptr<cancellation_token_source> m_disconnect_cts;
         std::mutex m_stop_lock;
-        cancellation_token m_start_completed_event;
+        cancellation_token_source m_start_completed_event;
         std::string m_connection_id;
         std::string m_connection_token;
         std::function<std::shared_ptr<http_client>(const signalr_client_config&)> m_http_client_factory;

--- a/src/signalrclient/default_http_client.cpp
+++ b/src/signalrclient/default_http_client.cpp
@@ -14,7 +14,8 @@
 
 namespace signalr
 {
-    void default_http_client::send(const std::string& url, const http_request& request, std::function<void(const http_response&, std::exception_ptr)> callback)
+    void default_http_client::send(const std::string& url, http_request& request,
+        std::function<void(const http_response&, std::exception_ptr)> callback, cancellation_token token)
     {
         web::http::method method;
         if (request.method == http_method::GET)
@@ -75,6 +76,11 @@ namespace signalr
                 }
             });
         }
+
+        token.register_callback([cts]()
+            {
+                cts.cancel();
+            });
 
         web::http::client::http_client client(utility::conversions::to_string_t(url));
         client.request(http_request, cts.get_token())

--- a/src/signalrclient/default_http_client.h
+++ b/src/signalrclient/default_http_client.h
@@ -11,6 +11,7 @@ namespace signalr
     class default_http_client : public http_client
     {
     public:
-        void send(const std::string& url, const http_request& request, std::function<void(const http_response&, std::exception_ptr)> callback) override;
+        void send(const std::string& url, http_request& request,
+            std::function<void(const http_response&, std::exception_ptr)> callback, cancellation_token token) override;
     };
 }

--- a/src/signalrclient/hub_connection_impl.cpp
+++ b/src/signalrclient/hub_connection_impl.cpp
@@ -108,7 +108,7 @@ namespace signalr
 
         m_connection->set_client_config(m_signalr_client_config);
         m_handshakeTask = std::make_shared<completion_event>();
-        m_disconnect_cts = std::make_shared<cancellation_token>();
+        m_disconnect_cts = std::make_shared<cancellation_token_source>();
         m_handshakeReceived = false;
         std::weak_ptr<hub_connection_impl> weak_connection = shared_from_this();
         m_connection->start([weak_connection, callback](std::exception_ptr start_exception)

--- a/src/signalrclient/hub_connection_impl.cpp
+++ b/src/signalrclient/hub_connection_impl.cpp
@@ -65,7 +65,18 @@ namespace signalr
             {
                 // start may be waiting on the handshake response so we complete it here, this no-ops if already set
                 connection->m_handshakeTask->set(std::make_exception_ptr(signalr_exception("connection closed while handshake was in progress.")));
-                connection->m_disconnect_cts->cancel();
+                try
+                {
+                    connection->m_disconnect_cts->cancel();
+                }
+                catch (const std::exception& ex)
+                {
+                    if (connection->m_logger.is_enabled(trace_level::warning))
+                    {
+                        connection->m_logger.log(trace_level::warning, std::string("disconnect event threw an exception during connection closure: ")
+                            .append(ex.what()));
+                    }
+                }
 
                 connection->m_callback_manager.clear("connection was stopped before invocation result was received");
 

--- a/src/signalrclient/hub_connection_impl.h
+++ b/src/signalrclient/hub_connection_impl.h
@@ -58,7 +58,7 @@ namespace signalr
         bool m_handshakeReceived;
         std::shared_ptr<completion_event> m_handshakeTask;
         std::function<void(std::exception_ptr)> m_disconnected;
-        std::shared_ptr<cancellation_token> m_disconnect_cts;
+        std::shared_ptr<cancellation_token_source> m_disconnect_cts;
         signalr_client_config m_signalr_client_config;
         std::unique_ptr<hub_protocol> m_protocol;
 

--- a/src/signalrclient/negotiate.cpp
+++ b/src/signalrclient/negotiate.cpp
@@ -16,7 +16,7 @@ namespace signalr
 
         void negotiate(std::shared_ptr<http_client> client, const std::string& base_url,
             const signalr_client_config& config,
-            std::function<void(negotiation_response&&, std::exception_ptr)> callback) noexcept
+            std::function<void(negotiation_response&&, std::exception_ptr)> callback, cancellation_token token) noexcept
         {
             std::string negotiate_url;
             try
@@ -133,7 +133,7 @@ namespace signalr
                 {
                     callback({}, std::current_exception());
                 }
-            });
+            }, token);
         }
     }
 }

--- a/src/signalrclient/negotiate.h
+++ b/src/signalrclient/negotiate.h
@@ -14,6 +14,6 @@ namespace signalr
     {
         void negotiate(std::shared_ptr<http_client> client, const std::string& base_url,
             const signalr_client_config& signalr_client_config,
-            std::function<void(negotiation_response&&, std::exception_ptr)> callback) noexcept;
+            std::function<void(negotiation_response&&, std::exception_ptr)> callback, cancellation_token token) noexcept;
     }
 }

--- a/src/signalrclient/websocket_transport.h
+++ b/src/signalrclient/websocket_transport.h
@@ -45,9 +45,9 @@ namespace signalr
         std::function<void(std::exception_ptr)> m_close_callback;
         signalr_client_config m_signalr_client_config;
 
-        std::shared_ptr<cancellation_token> m_receive_loop_cts;
+        std::shared_ptr<cancellation_token_source> m_receive_loop_cts;
 
-        void receive_loop(std::shared_ptr<cancellation_token> cts);
+        void receive_loop(std::shared_ptr<cancellation_token_source> cts);
 
         std::shared_ptr<websocket_client> safe_get_websocket_client();
     };

--- a/test/signalrclienttests/CMakeLists.txt
+++ b/test/signalrclienttests/CMakeLists.txt
@@ -36,6 +36,7 @@ include_directories(
 list (APPEND SOURCES
   ../../src/signalrclient/callback_manager.cpp
   ../../src/signalrclient/cancellation_token.cpp
+  ../../src/signalrclient/cancellation_token_source.cpp
   ../../src/signalrclient/connection.cpp
   ../../src/signalrclient/connection_impl.cpp
   ../../src/signalrclient/default_http_client.cpp

--- a/test/signalrclienttests/CMakeLists.txt
+++ b/test/signalrclienttests/CMakeLists.txt
@@ -1,5 +1,6 @@
 set (SOURCES
   callback_manager_tests.cpp
+  cancellation_token_source_tests.cpp
   case_insensitive_comparison_utils_tests.cpp
   connection_impl_tests.cpp
   handshake_tests.cpp
@@ -34,6 +35,7 @@ include_directories(
 # include main library sources for "internals visible to"
 list (APPEND SOURCES
   ../../src/signalrclient/callback_manager.cpp
+  ../../src/signalrclient/cancellation_token.cpp
   ../../src/signalrclient/connection.cpp
   ../../src/signalrclient/connection_impl.cpp
   ../../src/signalrclient/default_http_client.cpp

--- a/test/signalrclienttests/cancellation_token_source_tests.cpp
+++ b/test/signalrclienttests/cancellation_token_source_tests.cpp
@@ -179,7 +179,7 @@ TEST(cancellation_token_source, throws_if_callbacks_throw)
     }
     catch (const aggregate_exception& ex)
     {
-        ASSERT_STREQ("error from callback\nerror from second callback\n", ex.what());
+        ASSERT_STREQ("error from callback\nerror from second callback", ex.what());
     }
 }
 

--- a/test/signalrclienttests/cancellation_token_source_tests.cpp
+++ b/test/signalrclienttests/cancellation_token_source_tests.cpp
@@ -1,0 +1,247 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include "stdafx.h"
+#include <type_traits>
+#include "cancellation_token_source.h"
+#include "test_utils.h"
+
+using namespace signalr;
+
+TEST(cancellation_token_source, defaults_to_not_canceled)
+{
+    cancellation_token_source cts;
+    ASSERT_FALSE(cts.is_canceled());
+}
+
+TEST(cancellation_token_source, is_not_copyable)
+{
+    ASSERT_FALSE(std::is_copy_assignable<cancellation_token_source>::value);
+    ASSERT_FALSE(std::is_copy_constructible<cancellation_token_source>::value);
+}
+
+// This would be fine to support in the future if ever needed
+TEST(cancellation_token_source, is_not_moveable)
+{
+    ASSERT_FALSE(std::is_move_assignable<cancellation_token_source>::value);
+    ASSERT_FALSE(std::is_move_constructible<cancellation_token_source>::value);
+}
+
+TEST(cancellation_token_source, cancel_sets_canceled)
+{
+    cancellation_token_source cts;
+    cts.cancel();
+    ASSERT_TRUE(cts.is_canceled());
+}
+
+TEST(cancellation_token_source, can_be_reset)
+{
+    cancellation_token_source cts;
+    cts.cancel();
+    cts.reset();
+    ASSERT_FALSE(cts.is_canceled());
+}
+
+TEST(cancellation_token_source, callback_called_on_cancel)
+{
+    cancellation_token_source cts;
+    bool called = false;
+    cts.register_callback([&called]()
+        {
+            called = true;
+        });
+    cts.cancel();
+    ASSERT_TRUE(called);
+    ASSERT_TRUE(cts.is_canceled());
+}
+
+TEST(cancellation_token_source, callback_called_on_destruct)
+{
+    bool called = false;
+    {
+        cancellation_token_source cts;
+        cts.register_callback([&called]()
+            {
+                called = true;
+            });
+    }
+    ASSERT_TRUE(called);
+}
+
+TEST(cancellation_token_source, callback_called_if_already_canceled)
+{
+    cancellation_token_source cts;
+    cts.cancel();
+    ASSERT_TRUE(cts.is_canceled());
+
+    bool called = false;
+    cts.register_callback([&called]()
+        {
+            called = true;
+        });
+    ASSERT_TRUE(called);
+}
+
+TEST(cancellation_token_source, can_register_multiple_callbacks)
+{
+    cancellation_token_source cts;
+    bool called = false;
+    cts.register_callback([&called]()
+        {
+            called = true;
+        });
+    bool called2 = false;
+    cts.register_callback([&called2]()
+        {
+            called2 = true;
+        });
+
+    ASSERT_FALSE(called);
+    ASSERT_FALSE(called2);
+
+    cts.cancel();
+    ASSERT_TRUE(cts.is_canceled());
+    ASSERT_TRUE(called);
+    ASSERT_TRUE(called2);
+}
+
+TEST(cancellation_token_source, can_wait_for_cancel)
+{
+    cancellation_token_source cts;
+
+    auto thread = std::thread([&cts]()
+        {
+            cts.cancel();
+        });
+    thread.join();
+
+    ASSERT_EQ(0, cts.wait());
+    ASSERT_TRUE(cts.is_canceled());
+}
+
+TEST(cancellation_token_source, can_timeout_wait)
+{
+    cancellation_token_source cts;
+
+    auto mre = manual_reset_event<void>();
+    auto thread = std::thread([&cts, &mre]()
+        {
+            mre.get();
+            cts.cancel();
+        });
+
+    ASSERT_EQ(cancellation_token_source::timeout_infinite, cts.wait(100));
+    ASSERT_FALSE(cts.is_canceled());
+
+    mre.set();
+    thread.join();
+
+    ASSERT_TRUE(cts.is_canceled());
+}
+
+TEST(cancellation_token_source, throw_method_throws_if_canceled)
+{
+    cancellation_token_source cts;
+
+    // noop
+    cts.throw_if_cancellation_requested();
+
+    cts.cancel();
+    try
+    {
+        cts.throw_if_cancellation_requested();
+        ASSERT_TRUE(false);
+    }
+    catch (canceled_exception)
+    {
+    }
+}
+
+TEST(cancellation_token, can_be_canceled)
+{
+    auto cts = std::make_shared<cancellation_token_source>();
+    auto token = get_cancellation_token(cts);
+
+    ASSERT_FALSE(token.is_canceled());
+
+    cts->cancel();
+
+    ASSERT_TRUE(token.is_canceled());
+}
+
+TEST(cancellation_token, can_register_callbacks)
+{
+    auto cts = std::make_shared<cancellation_token_source>();
+    auto token = get_cancellation_token(cts);
+    bool called = false;
+    token.register_callback([&called]()
+        {
+            called = true;
+        });
+    bool called2 = false;
+    token.register_callback([&called2]()
+        {
+            called2 = true;
+        });
+
+    ASSERT_FALSE(called);
+    ASSERT_FALSE(called2);
+
+    cts->cancel();
+
+    ASSERT_TRUE(token.is_canceled());
+    ASSERT_TRUE(called);
+    ASSERT_TRUE(called2);
+}
+
+TEST(cancellation_token, is_canceled_with_destructed_cts)
+{
+    auto cts = std::make_shared<cancellation_token_source>();
+    auto token = get_cancellation_token(cts);
+
+    cts.reset();
+
+    ASSERT_TRUE(cts == nullptr);
+    ASSERT_TRUE(token.is_canceled());
+}
+
+TEST(cancellation_token, is_copyable_and_moveable)
+{
+    ASSERT_TRUE(std::is_copy_assignable<cancellation_token>::value);
+    ASSERT_TRUE(std::is_copy_constructible<cancellation_token>::value);
+
+    ASSERT_TRUE(std::is_move_assignable<cancellation_token>::value);
+    ASSERT_TRUE(std::is_move_constructible<cancellation_token>::value);
+}
+
+TEST(cancellation_token, callback_called_when_already_canceled)
+{
+    auto cts = std::make_shared<cancellation_token_source>();
+    auto token = get_cancellation_token(cts);
+
+    cts->cancel();
+    ASSERT_TRUE(token.is_canceled());
+
+    bool called = false;
+    token.register_callback([&called]()
+        {
+            called = true;
+        });
+    ASSERT_TRUE(called);
+}
+
+TEST(cancellation_token, callback_called_when_cts_already_destructed)
+{
+    auto cts = std::make_shared<cancellation_token_source>();
+    auto token = get_cancellation_token(cts);
+
+    cts.reset();
+
+    bool called = false;
+    token.register_callback([&called]()
+        {
+            called = true;
+        });
+    ASSERT_TRUE(called);
+}

--- a/test/signalrclienttests/connection_impl_tests.cpp
+++ b/test/signalrclienttests/connection_impl_tests.cpp
@@ -109,7 +109,7 @@ TEST(connection_impl_start, connection_state_is_connected_when_connection_establ
 
 TEST(connection_impl_start, connection_state_is_disconnected_when_connection_cannot_be_established)
 {
-    auto http_client = std::shared_ptr<test_http_client>(new test_http_client([](const std::string&, http_request)
+    auto http_client = std::shared_ptr<test_http_client>(new test_http_client([](const std::string&, http_request, cancellation_token)
         {
             return http_response{ 404, "" };
         }));
@@ -247,7 +247,7 @@ TEST(connection_impl_start, start_logs_exceptions)
 {
     std::shared_ptr<log_writer> writer(std::make_shared<memory_log_writer>());
 
-    auto http_client = std::shared_ptr<test_http_client>(new test_http_client([](const std::string&, http_request)
+    auto http_client = std::shared_ptr<test_http_client>(new test_http_client([](const std::string&, http_request, cancellation_token)
         {
             return http_response{ 404, "" };
         }));
@@ -280,7 +280,7 @@ TEST(connection_impl_start, start_logs_exceptions)
 
 TEST(connection_impl_start, start_propagates_exceptions_from_negotiate)
 {
-    auto http_client = std::shared_ptr<test_http_client>(new test_http_client([](const std::string&, http_request) -> http_response
+    auto http_client = std::shared_ptr<test_http_client>(new test_http_client([](const std::string&, http_request, cancellation_token) -> http_response
         {
             throw custom_exception();
         }));
@@ -390,7 +390,7 @@ TEST(connection_impl_start, start_fails_if_negotiate_request_fails)
 {
     std::shared_ptr<log_writer> writer(std::make_shared<memory_log_writer>());
 
-    auto http_client = std::shared_ptr<test_http_client>(new test_http_client([](const std::string&, http_request)
+    auto http_client = std::shared_ptr<test_http_client>(new test_http_client([](const std::string&, http_request, cancellation_token)
         {
             return http_response{ 400, "" };
         }));
@@ -425,7 +425,7 @@ TEST(connection_impl_start, start_fails_if_negotiate_response_has_error)
 {
     std::shared_ptr<log_writer> writer(std::make_shared<memory_log_writer>());
 
-    auto http_client = std::shared_ptr<test_http_client>(new test_http_client([](const std::string& url, http_request)
+    auto http_client = std::shared_ptr<test_http_client>(new test_http_client([](const std::string& url, http_request, cancellation_token)
         {
             auto response_body =
                 url.find("/negotiate") != std::string::npos
@@ -473,7 +473,7 @@ TEST(connection_impl_start, start_fails_if_negotiate_response_does_not_have_webs
 {
     std::shared_ptr<log_writer> writer(std::make_shared<memory_log_writer>());
 
-    auto http_client = std::shared_ptr<test_http_client>(new test_http_client([](const std::string& url, http_request)
+    auto http_client = std::shared_ptr<test_http_client>(new test_http_client([](const std::string& url, http_request, cancellation_token)
         {
             auto response_body =
                 url.find("/negotiate") != std::string::npos
@@ -513,7 +513,7 @@ TEST(connection_impl_start, start_fails_if_negotiate_response_does_not_have_tran
 {
     std::shared_ptr<log_writer> writer(std::make_shared<memory_log_writer>());
 
-    auto http_client = std::shared_ptr<test_http_client>(new test_http_client([](const std::string& url, http_request)
+    auto http_client = std::shared_ptr<test_http_client>(new test_http_client([](const std::string& url, http_request, cancellation_token)
         {
             auto response_body =
                 url.find("/negotiate") != std::string::npos
@@ -553,7 +553,7 @@ TEST(connection_impl_start, start_fails_if_negotiate_response_is_invalid)
 {
     std::shared_ptr<log_writer> writer(std::make_shared<memory_log_writer>());
 
-    auto http_client = std::shared_ptr<test_http_client>(new test_http_client([](const std::string& url, http_request)
+    auto http_client = std::shared_ptr<test_http_client>(new test_http_client([](const std::string& url, http_request, cancellation_token)
         {
             auto response_body =
                 url.find("/negotiate") != std::string::npos
@@ -590,7 +590,7 @@ TEST(connection_impl_start, negotiate_follows_redirect)
 {
     std::shared_ptr<log_writer> writer(std::make_shared<memory_log_writer>());
 
-    auto http_client = std::shared_ptr<test_http_client>(new test_http_client([](const std::string& url, http_request)
+    auto http_client = std::shared_ptr<test_http_client>(new test_http_client([](const std::string& url, http_request, cancellation_token)
         {
             std::string response_body = "";
             if (url.find("/negotiate") != std::string::npos)
@@ -645,7 +645,7 @@ TEST(connection_impl_start, negotiate_redirect_uses_accessToken)
     std::shared_ptr<log_writer> writer(std::make_shared<memory_log_writer>());
     std::string accessToken;
 
-    auto http_client = std::shared_ptr<test_http_client>(new test_http_client([&accessToken](const std::string& url, http_request request)
+    auto http_client = std::shared_ptr<test_http_client>(new test_http_client([&accessToken](const std::string& url, http_request request, cancellation_token)
         {
             std::string response_body = "";
             if (url.find("/negotiate") != std::string::npos)
@@ -701,7 +701,7 @@ TEST(connection_impl_start, negotiate_fails_after_too_many_redirects)
 {
     std::shared_ptr<log_writer> writer(std::make_shared<memory_log_writer>());
 
-    auto http_client = std::shared_ptr<test_http_client>(new test_http_client([](const std::string& url, http_request)
+    auto http_client = std::shared_ptr<test_http_client>(new test_http_client([](const std::string& url, http_request, cancellation_token)
         {
             std::string response_body = "";
             if (url.find("/negotiate") != std::string::npos)
@@ -743,7 +743,7 @@ TEST(connection_impl_start, negotiate_fails_if_ProtocolVersion_in_response)
 {
     std::shared_ptr<log_writer> writer(std::make_shared<memory_log_writer>());
 
-    auto http_client = std::shared_ptr<test_http_client>(new test_http_client([](const std::string& url, http_request)
+    auto http_client = std::shared_ptr<test_http_client>(new test_http_client([](const std::string& url, http_request, cancellation_token)
         {
             std::string response_body = "";
             if (url.find("/negotiate") != std::string::npos)
@@ -784,7 +784,7 @@ TEST(connection_impl_start, negotiate_redirect_does_not_overwrite_url)
     std::shared_ptr<log_writer> writer(std::make_shared<memory_log_writer>());
     int redirectCount = 0;
 
-    auto http_client = std::shared_ptr<test_http_client>(new test_http_client([&redirectCount](const std::string& url, http_request)
+    auto http_client = std::shared_ptr<test_http_client>(new test_http_client([&redirectCount](const std::string& url, http_request, cancellation_token)
         {
             std::string response_body = "";
             if (url.find("/negotiate") != std::string::npos)
@@ -852,7 +852,7 @@ TEST(connection_impl_start, negotiate_redirect_uses_own_query_string)
             callback(std::make_exception_ptr(std::runtime_error("connecting failed")));
         });
 
-    auto http_client = std::shared_ptr<test_http_client>(new test_http_client([](const std::string& url, http_request)
+    auto http_client = std::shared_ptr<test_http_client>(new test_http_client([](const std::string& url, http_request, cancellation_token)
         {
             std::string response_body = "";
             if (url.find("/negotiate") != std::string::npos)
@@ -913,7 +913,7 @@ TEST(connection_impl_start, negotiate_with_negotiateVersion_uses_connectionToken
             callback(std::make_exception_ptr(std::runtime_error("connecting failed")));
         });
 
-    auto http_client = std::shared_ptr<test_http_client>(new test_http_client([](const std::string& url, http_request)
+    auto http_client = std::shared_ptr<test_http_client>(new test_http_client([](const std::string& url, http_request, cancellation_token)
         {
             std::string response_body = "";
             if (url.find("/negotiate") != std::string::npos)
@@ -966,7 +966,7 @@ TEST(connection_impl_start, correct_connection_id_returned_with_negotiateVersion
             callback(nullptr);
         });
 
-    auto http_client = std::shared_ptr<test_http_client>(new test_http_client([](const std::string& url, http_request)
+    auto http_client = std::shared_ptr<test_http_client>(new test_http_client([](const std::string& url, http_request, cancellation_token)
         {
             std::string response_body = "";
             if (url.find("/negotiate") != std::string::npos)
@@ -1006,7 +1006,7 @@ TEST(connection_impl_start, negotiate_can_be_skipped)
 
     bool negotiate_called = false;
 
-    auto http_client = std::shared_ptr<test_http_client>(new test_http_client([&negotiate_called](const std::string& url, http_request request)
+    auto http_client = std::shared_ptr<test_http_client>(new test_http_client([&negotiate_called](const std::string& url, http_request request, cancellation_token)
         {
             negotiate_called = true;
 
@@ -1048,7 +1048,7 @@ TEST(connection_impl_start, negotiate_can_be_skipped)
 TEST(connection_impl_process_response, process_response_logs_messages)
 {
     std::shared_ptr<log_writer> writer(std::make_shared<memory_log_writer>());
-    auto wait_receive = std::make_shared<cancellation_token>();
+    auto wait_receive = std::make_shared<cancellation_token_source>();
     auto websocket_client = create_test_websocket_client();
     auto connection = create_connection(websocket_client, writer, trace_level::debug);
 
@@ -1181,7 +1181,7 @@ TEST(connection_impl_set_message_received, callback_invoked_when_message_receive
 
     auto message = std::make_shared<std::string>();
 
-    auto message_received_event = std::make_shared<cancellation_token>();
+    auto message_received_event = std::make_shared<cancellation_token_source>();
     connection->set_message_received([message, message_received_event](const std::string& m)
         {
             if (m == "Test")
@@ -1218,7 +1218,7 @@ TEST(connection_impl_set_message_received, exception_from_callback_caught_and_lo
     std::shared_ptr<log_writer> writer(std::make_shared<memory_log_writer>());
     auto connection = create_connection(websocket_client, writer, trace_level::error);
 
-    auto message_received_event = std::make_shared<cancellation_token>();
+    auto message_received_event = std::make_shared<cancellation_token_source>();
     connection->set_message_received([message_received_event](const std::string& m)
         {
             if (m == "throw")
@@ -1258,7 +1258,7 @@ TEST(connection_impl_set_message_received, non_std_exception_from_callback_caugh
     std::shared_ptr<log_writer> writer(std::make_shared<memory_log_writer>());
     auto connection = create_connection(websocket_client, writer, trace_level::error);
 
-    auto message_received_event = std::make_shared<cancellation_token>();
+    auto message_received_event = std::make_shared<cancellation_token_source>();
     connection->set_message_received([message_received_event](const std::string& m)
         {
             if (m == "throw")
@@ -1351,7 +1351,7 @@ TEST(connection_impl_stop, stopping_disconnected_connection_is_no_op)
 
 TEST(connection_impl_stop, stopping_disconnecting_connection_returns_canceled_task)
 {
-    cancellation_token close_event;
+    cancellation_token_source close_event;
     auto writer = std::shared_ptr<log_writer>{ std::make_shared<memory_log_writer>() };
 
     auto websocket_client = create_test_websocket_client(
@@ -1532,9 +1532,9 @@ TEST(connection_impl_stop, dtor_stops_the_connection)
 
 TEST(connection_impl_stop, stop_cancels_ongoing_start_request)
 {
-    auto disconnect_completed_event = std::make_shared<cancellation_token>();
+    auto disconnect_completed_event = std::make_shared<cancellation_token_source>();
 
-    auto http_client = std::shared_ptr<test_http_client>(new test_http_client([](const std::string& url, http_request)
+    auto http_client = std::shared_ptr<test_http_client>(new test_http_client([](const std::string& url, http_request, cancellation_token)
         {
             auto response_body =
                 url.find("/negotiate") != std::string::npos
@@ -1604,7 +1604,7 @@ TEST(connection_impl_stop, ongoing_start_request_canceled_if_connection_stopped_
 {
     auto stop_mre = manual_reset_event<void>();
     auto done_mre = manual_reset_event<void>();
-    auto http_client = std::shared_ptr<test_http_client>(new test_http_client([&stop_mre, &done_mre](const std::string& url, http_request)
+    auto http_client = std::shared_ptr<test_http_client>(new test_http_client([&stop_mre, &done_mre](const std::string& url, http_request, cancellation_token)
         {
             stop_mre.get();
 
@@ -1784,7 +1784,7 @@ TEST(connection_impl_config, custom_headers_set_in_requests)
 {
     auto writer = std::shared_ptr<log_writer>{ std::make_shared<memory_log_writer>() };
 
-    auto http_client = std::shared_ptr<test_http_client>(new test_http_client([](const std::string& url, http_request)
+    auto http_client = std::shared_ptr<test_http_client>(new test_http_client([](const std::string& url, http_request, cancellation_token)
         {
             auto response_body =
                 url.find("/negotiate") != std::string::npos
@@ -1963,7 +1963,7 @@ TEST(connection_id, connection_id_reset_when_starting_connection)
 
     auto websocket_client = create_test_websocket_client();
 
-    auto http_client = std::shared_ptr<test_http_client>(new test_http_client([&fail_http_requests](const std::string& url, http_request)
+    auto http_client = std::shared_ptr<test_http_client>(new test_http_client([&fail_http_requests](const std::string& url, http_request, cancellation_token)
         {
             if (!fail_http_requests) {
                 auto response_body =
@@ -2014,6 +2014,68 @@ TEST(connection_id, connection_id_reset_when_starting_connection)
         });
 
     mre.get();
+
+    ASSERT_EQ("", connection->get_connection_id());
+}
+
+TEST(connection_impl_stop, triggers_http_send_token)
+{
+    auto writer = std::shared_ptr<log_writer>{ std::make_shared<memory_log_writer>() };
+
+    auto send_started = manual_reset_event<void>();
+    auto websocket_client = create_test_websocket_client();
+    auto http_client = std::shared_ptr<test_http_client>(new test_http_client([&send_started](const std::string& url, http_request, cancellation_token token)
+        {
+            send_started.set();
+            auto mre = manual_reset_event<void>();
+            token.register_callback([&mre]()
+                {
+                    mre.set();
+                });
+            mre.get();
+            auto response_body =
+                url.find("/negotiate") != std::string::npos
+                ? "{\"connectionId\" : \"f7707523-307d-4cba-9abf-3eef701241e8\", "
+                "\"availableTransports\" : [ { \"transport\": \"WebSockets\", \"transferFormats\": [ \"Text\", \"Binary\" ] } ] }"
+                : "";
+
+            return http_response{ 200, response_body };
+        }));
+    auto connection =
+        connection_impl::create(create_uri(), trace_level::verbose, std::make_shared<memory_log_writer>(),
+            [http_client](const signalr_client_config& config) {
+                http_client->set_scheduler(config.get_scheduler());
+                return http_client;
+            }, [websocket_client](const signalr_client_config& config)
+            {
+                websocket_client->set_config(config);
+                return websocket_client;
+            });
+
+    auto start_mre = manual_reset_event<void>();
+    connection->start([&start_mre](std::exception_ptr exception)
+        {
+            start_mre.set(exception);
+        });
+
+    send_started.get();
+
+    auto stop_mre = manual_reset_event<void>();
+    connection->stop([&stop_mre](std::exception_ptr exception)
+        {
+            stop_mre.set(exception);
+        }, nullptr);
+
+    try
+    {
+        start_mre.get();
+        ASSERT_TRUE(false);
+    }
+    catch (const signalr::canceled_exception&)
+    {
+    }
+
+    stop_mre.get();
 
     ASSERT_EQ("", connection->get_connection_id());
 }

--- a/test/signalrclienttests/hub_connection_tests.cpp
+++ b/test/signalrclienttests/hub_connection_tests.cpp
@@ -107,7 +107,7 @@ TEST(url, negotiate_appended_to_url)
     for (const auto& base_url : base_urls)
     {
         std::string requested_url;
-        auto http_client = std::make_shared<test_http_client>([&requested_url](const std::string& url, http_request)
+        auto http_client = std::make_shared<test_http_client>([&requested_url](const std::string& url, http_request, cancellation_token)
         {
             requested_url = url;
             return http_response{ 404, "" };
@@ -430,7 +430,7 @@ TEST(start, start_fails_if_handshake_times_out)
 
 TEST(start, propogates_exception_from_negotiate)
 {
-    auto http_client = std::make_shared<test_http_client>([](const std::string& url, http_request) -> http_response
+    auto http_client = std::make_shared<test_http_client>([](const std::string& url, http_request, cancellation_token) -> http_response
         {
             throw custom_exception();
         });
@@ -825,7 +825,7 @@ TEST(hub_invocation, hub_connection_invokes_users_code_on_hub_invocations)
     auto hub_connection = create_hub_connection(websocket_client);
 
     auto payload = std::make_shared<signalr::value>();
-    auto on_broadcast_event = std::make_shared<cancellation_token>();
+    auto on_broadcast_event = std::make_shared<cancellation_token_source>();
     hub_connection.on("broadCAST", [on_broadcast_event, payload](const signalr::value& message)
     {
         *payload = message;
@@ -859,7 +859,7 @@ TEST(hub_invocation, hub_connection_can_receive_handshake_and_message_in_same_pa
     auto hub_connection = create_hub_connection(websocket_client);
 
     auto payload = std::make_shared<signalr::value>();
-    auto on_broadcast_event = std::make_shared<cancellation_token>();
+    auto on_broadcast_event = std::make_shared<cancellation_token_source>();
     hub_connection.on("broadCAST", [on_broadcast_event, payload](const signalr::value& message)
         {
             *payload = message;
@@ -893,7 +893,7 @@ TEST(hub_invocation, hub_connection_can_receive_multiple_messages_in_same_payloa
 
     auto payload = std::make_shared<signalr::value>();
     int count = 0;
-    auto on_broadcast_event = std::make_shared<cancellation_token>();
+    auto on_broadcast_event = std::make_shared<cancellation_token_source>();
     hub_connection.on("broadCAST", [&count, on_broadcast_event, payload](const signalr::value& message)
         {
             ++count;
@@ -1733,7 +1733,7 @@ TEST(config, can_replace_scheduler)
 
     mre.get();
 
-    ASSERT_EQ(5, scheduler->schedule_count);
+    ASSERT_EQ(6, scheduler->schedule_count);
 }
 
 class throw_hub_protocol : public hub_protocol

--- a/test/signalrclienttests/hub_connection_tests.cpp
+++ b/test/signalrclienttests/hub_connection_tests.cpp
@@ -1733,7 +1733,7 @@ TEST(config, can_replace_scheduler)
 
     mre.get();
 
-    ASSERT_EQ(6, scheduler->schedule_count);
+    ASSERT_EQ(5, scheduler->schedule_count);
 }
 
 class throw_hub_protocol : public hub_protocol

--- a/test/signalrclienttests/negotiate_tests.cpp
+++ b/test/signalrclienttests/negotiate_tests.cpp
@@ -13,7 +13,7 @@ using namespace signalr;
 TEST(negotiate, request_created_with_correct_url)
 {
     std::string requested_url;
-    auto http_client = std::make_shared<test_http_client>([&requested_url](const std::string& url, http_request request)
+    auto http_client = std::make_shared<test_http_client>([&requested_url](const std::string& url, http_request request, cancellation_token token)
     {
         std::string response_body(
             "{ \"connectionId\" : \"f7707523-307d-4cba-9abf-3eef701241e8\", "
@@ -25,12 +25,13 @@ TEST(negotiate, request_created_with_correct_url)
 
     http_client->set_scheduler(std::make_shared<signalr_default_scheduler>());
 
+    auto cts = std::make_shared<cancellation_token_source>();
     auto mre = manual_reset_event<void>();
     negotiate::negotiate(http_client, "http://fake/signalr", signalr_client_config(),
         [&mre](signalr::negotiation_response&&, std::exception_ptr exception)
         {
             mre.set();
-        });
+        }, get_cancellation_token(cts));
 
     mre.get();
     ASSERT_EQ("http://fake/signalr/negotiate?negotiateVersion=1", requested_url);
@@ -38,7 +39,7 @@ TEST(negotiate, request_created_with_correct_url)
 
 TEST(negotiate, negotiation_request_sent_and_response_serialized)
 {
-    auto request_factory = std::make_shared<test_http_client>([](const std::string&, http_request request)
+    auto request_factory = std::make_shared<test_http_client>([](const std::string&, http_request request, cancellation_token token)
     {
         std::string response_body(
             "{\"connectionId\" : \"f7707523-307d-4cba-9abf-3eef701241e8\", "
@@ -50,12 +51,13 @@ TEST(negotiate, negotiation_request_sent_and_response_serialized)
 
     request_factory->set_scheduler(std::make_shared<signalr_default_scheduler>());
 
+    auto cts = std::make_shared<cancellation_token_source>();
     auto mre = manual_reset_event<negotiation_response>();
     negotiate::negotiate(request_factory, "http://fake/signalr", signalr_client_config(),
         [&mre](negotiation_response&& response, std::exception_ptr exception)
         {
             mre.set(response);
-        });
+        }, get_cancellation_token(cts));
 
     auto response = mre.get();
 
@@ -71,7 +73,7 @@ TEST(negotiate, negotiation_request_sent_and_response_serialized)
 
 TEST(negotiate, negotiation_response_with_redirect)
 {
-    auto request_factory = std::make_shared<test_http_client>([](const std::string&, http_request request)
+    auto request_factory = std::make_shared<test_http_client>([](const std::string&, http_request request, cancellation_token token)
     {
         std::string response_body(
             "{\"url\" : \"http://redirect\", "
@@ -82,12 +84,13 @@ TEST(negotiate, negotiation_response_with_redirect)
 
     request_factory->set_scheduler(std::make_shared<signalr_default_scheduler>());
 
+    auto cts = std::make_shared<cancellation_token_source>();
     auto mre = manual_reset_event<negotiation_response>();
     negotiate::negotiate(request_factory, "http://fake/signalr", signalr_client_config(),
         [&mre](negotiation_response&& response, std::exception_ptr exception)
         {
             mre.set(response);
-        });
+        }, get_cancellation_token(cts));
 
     auto response = mre.get();
 
@@ -97,7 +100,7 @@ TEST(negotiate, negotiation_response_with_redirect)
 
 TEST(negotiate, negotiation_response_with_negotiateVersion)
 {
-    auto request_factory = std::make_shared<test_http_client>([](const std::string&, http_request request)
+    auto request_factory = std::make_shared<test_http_client>([](const std::string&, http_request request, cancellation_token token)
         {
             std::string response_body(
                 "{\"connectionId\" : \"f7707523-307d-4cba-9abf-3eef701241e8\", "
@@ -111,12 +114,13 @@ TEST(negotiate, negotiation_response_with_negotiateVersion)
 
     request_factory->set_scheduler(std::make_shared<signalr_default_scheduler>());
 
+    auto cts = std::make_shared<cancellation_token_source>();
     auto mre = manual_reset_event<negotiation_response>();
     negotiate::negotiate(request_factory, "http://fake/signalr", signalr_client_config(),
         [&mre](negotiation_response&& response, std::exception_ptr exception)
         {
             mre.set(response);
-        });
+        }, get_cancellation_token(cts));
 
     auto response = mre.get();
 
@@ -126,7 +130,7 @@ TEST(negotiate, negotiation_response_with_negotiateVersion)
 
 TEST(negotiate, negotiation_response_with_future_negotiateVersion)
 {
-    auto request_factory = std::make_shared<test_http_client>([](const std::string&, http_request request)
+    auto request_factory = std::make_shared<test_http_client>([](const std::string&, http_request request, cancellation_token token)
         {
             std::string response_body(
                 "{\"connectionId\" : \"f7707523-307d-4cba-9abf-3eef701241e8\", "
@@ -140,12 +144,13 @@ TEST(negotiate, negotiation_response_with_future_negotiateVersion)
 
     request_factory->set_scheduler(std::make_shared<signalr_default_scheduler>());
 
+    auto cts = std::make_shared<cancellation_token_source>();
     auto mre = manual_reset_event<negotiation_response>();
     negotiate::negotiate(request_factory, "http://fake/signalr", signalr_client_config(),
         [&mre](negotiation_response&& response, std::exception_ptr exception)
         {
             mre.set(response);
-        });
+        }, get_cancellation_token(cts));
 
     auto response = mre.get();
 

--- a/test/signalrclienttests/stdafx.h
+++ b/test/signalrclienttests/stdafx.h
@@ -13,5 +13,5 @@
 #endif
 
 #include "gtest/gtest.h"
-#include "../../src/signalrclient/cancellation_token.h"
+#include "../../src/signalrclient/cancellation_token_source.h"
 #include <thread>

--- a/test/signalrclienttests/test_http_client.cpp
+++ b/test/signalrclienttests/test_http_client.cpp
@@ -5,21 +5,22 @@
 #include "stdafx.h"
 #include "test_http_client.h"
 
-test_http_client::test_http_client(std::function<http_response(const std::string& url, http_request request)> create_http_response_fn)
+test_http_client::test_http_client(std::function<http_response(const std::string& url, http_request request, cancellation_token token)> create_http_response_fn)
     : m_http_response(create_http_response_fn)
 {
 }
 
-void test_http_client::send(const std::string& url, const http_request& request, std::function<void(const http_response&, std::exception_ptr)> callback)
+void test_http_client::send(const std::string& url, http_request& request,
+    std::function<void(const http_response&, std::exception_ptr)> callback, cancellation_token token)
 {
-    auto create_reponse = m_http_response;
-    m_scheduler->schedule([create_reponse, url, request, callback]()
+    auto create_response = m_http_response;
+    m_scheduler->schedule([create_response, url, request, callback, token]()
         {
             http_response response;
             std::exception_ptr exception;
             try
             {
-                response = create_reponse(url, request);
+                response = create_response(url, request, token);
             }
             catch (...)
             {

--- a/test/signalrclienttests/test_http_client.h
+++ b/test/signalrclienttests/test_http_client.h
@@ -12,12 +12,13 @@ using namespace signalr;
 class test_http_client : public http_client
 {
 public:
-    test_http_client(std::function<http_response(const std::string& url, http_request request)> create_http_response_fn);
-    void send(const std::string& url, const http_request& request, std::function<void(const http_response&, std::exception_ptr)> callback) override;
+    test_http_client(std::function<http_response(const std::string& url, http_request request, cancellation_token token)> create_http_response_fn);
+    void send(const std::string& url, http_request& request,
+        std::function<void(const http_response&, std::exception_ptr)> callback, cancellation_token token) override;
 
     void set_scheduler(std::shared_ptr<scheduler> scheduler);
 private:
-    std::function<http_response(const std::string& url, http_request request)> m_http_response;
+    std::function<http_response(const std::string& url, http_request request, cancellation_token token)> m_http_response;
 
     std::shared_ptr<scheduler> m_scheduler;
 };

--- a/test/signalrclienttests/test_utils.cpp
+++ b/test/signalrclienttests/test_utils.cpp
@@ -34,7 +34,7 @@ std::function<std::shared_ptr<signalr::http_client>(const signalr::signalr_clien
 {
     return [](const signalr_client_config& config)
     {
-        auto client = std::shared_ptr<test_http_client>(new test_http_client([](const std::string& url, http_request request)
+        auto client = std::shared_ptr<test_http_client>(new test_http_client([](const std::string& url, http_request request, cancellation_token)
             {
                 auto response_body =
                     url.find_first_of("/negotiate") != 0

--- a/test/signalrclienttests/test_websocket_client.h
+++ b/test/signalrclienttests/test_websocket_client.h
@@ -7,7 +7,7 @@
 #include <functional>
 #include "signalrclient/websocket_client.h"
 #include "test_utils.h"
-#include "cancellation_token.h"
+#include "cancellation_token_source.h"
 #include <queue>
 #include "signalrclient/signalr_client_config.h"
 
@@ -38,8 +38,8 @@ public:
     void receive_message(const std::string& message);
     void receive_message(std::exception_ptr ex);
 
-    cancellation_token receive_loop_started;
-    cancellation_token handshake_sent;
+    cancellation_token_source receive_loop_started;
+    cancellation_token_source handshake_sent;
     int receive_count;
 
 private:
@@ -56,7 +56,7 @@ private:
     std::mutex m_receive_lock;
     bool m_stopped;
     manual_reset_event<void> m_receive_waiting;
-    cancellation_token m_receive_loop_not_running;
+    cancellation_token_source m_receive_loop_not_running;
     std::shared_ptr<scheduler> m_scheduler;
 };
 

--- a/test/signalrclienttests/websocket_transport_tests.cpp
+++ b/test/signalrclienttests/websocket_transport_tests.cpp
@@ -468,7 +468,7 @@ TEST(websocket_transport_receive_loop, process_response_callback_called_when_mes
 {
     auto client = std::make_shared<test_websocket_client>();
 
-    auto process_response_event = std::make_shared<cancellation_token>();
+    auto process_response_event = std::make_shared<cancellation_token_source>();
     auto msg = std::make_shared<std::string>();
 
     auto process_response = [msg, process_response_event](const std::string& message, std::exception_ptr exception)
@@ -510,7 +510,7 @@ TEST(websocket_transport_receive_loop, error_callback_called_when_exception_thro
         callback(nullptr);
     });
 
-    auto error_event = std::make_shared<cancellation_token>();
+    auto error_event = std::make_shared<cancellation_token_source>();
     auto exception_msg = std::make_shared<std::string>();
 
     auto error_callback = [exception_msg, error_event](std::exception_ptr exception)


### PR DESCRIPTION
Relies on https://github.com/aspnet/SignalR-Client-Cpp/pull/61 so that needs to go in first.

This adds a way to cancel an http request, such as if stop is called while negotiate is in-progress