### PR TITLE
Update CMake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.5)
+cmake_minimum_required (VERSION 3.14)
 
 if(DEFINED ENV{VCPKG_ROOT} AND NOT DEFINED CMAKE_TOOLCHAIN_FILE)
   set(CMAKE_TOOLCHAIN_FILE "$ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake")


### PR DESCRIPTION
Vcpkg uses cmake 3.14 internally https://github.com/microsoft/vcpkg/issues/9803#issuecomment-577688479 (at least last year it did).

Using a lower version of cmake can cause issues, see https://github.com/dotnet/aspnetcore/issues/35059

So lets raise our minimum version.