### PR TITLE
Destruct users websocket_client after we're done with it

### DIFF
--- a/src/signalrclient/websocket_transport.cpp
+++ b/src/signalrclient/websocket_transport.cpp
@@ -245,12 +245,12 @@ namespace signalr
 
         websocket_client->stop([logger, callback, close_callback, weak_websocket_client](std::exception_ptr exception)
             {
+                // Grab a strong reference to the websocket_client so that it can't get destructed in the middle of this lambda running.
+                // Because we capture by weak reference we aren't causing any circular references, and the strong reference only lasts until this lambda returns.
+                auto websocket_client = weak_websocket_client.lock();
+
                 try
                 {
-                    // Grab a strong reference to the websocket_client so that it can't get destructed in the middle of this lambda running.
-                    // Because we capture by weak reference we aren't causing any circular references, and the strong reference only lasts until this lambda returns.
-                    auto websocket_client = weak_websocket_client.lock();
-
                     close_callback(exception);
                     if (exception != nullptr)
                     {


### PR DESCRIPTION
Relies on https://github.com/aspnet/SignalR-Client-Cpp/pull/71

Fixes https://github.com/dotnet/aspnetcore/issues/36808