### PR TITLE
Fix stop to properly wait

### DIFF
--- a/include/signalrclient/connection.h
+++ b/include/signalrclient/connection.h
@@ -12,6 +12,8 @@
 #include "log_writer.h"
 #include "signalr_client_config.h"
 #include "transfer_format.h"
+#include "http_client.h"
+#include "websocket_client.h"
 
 namespace signalr
 {
@@ -20,9 +22,11 @@ namespace signalr
     class connection
     {
     public:
-        typedef std::function<void __cdecl(const std::string&)> message_received_handler;
+        typedef std::function<void __cdecl(std::string&&)> message_received_handler;
 
-        SIGNALRCLIENT_API explicit connection(const std::string& url, trace_level trace_level = trace_level::info, std::shared_ptr<log_writer> log_writer = nullptr);
+        SIGNALRCLIENT_API explicit connection(const std::string& url, trace_level trace_level = trace_level::info, std::shared_ptr<log_writer> log_writer = nullptr,
+            std::function<std::shared_ptr<http_client>(const signalr_client_config&)> http_client_factory = nullptr,
+            std::function<std::shared_ptr<websocket_client>(const signalr_client_config&)> websocket_factory = nullptr, bool skip_negotiation = false);
 
         SIGNALRCLIENT_API ~connection();
 

--- a/src/signalrclient/cancellation_token_source.h
+++ b/src/signalrclient/cancellation_token_source.h
@@ -53,11 +53,14 @@ namespace signalr
         cancellation_token_source(const cancellation_token_source&) = delete;
         cancellation_token_source& operator=(const cancellation_token_source&) = delete;
 
-        void cancel()
+        // returns false if already canceled, otherwise true if this cancels
+        bool cancel()
         {
+            bool signal = false;
             std::vector<std::function<void()>> callbacks;
             {
                 std::lock_guard<std::mutex> lock(m_lock);
+                signal = !m_signaled;
                 m_signaled = true;
                 m_condition.notify_all();
                 callbacks = std::move(m_callbacks);
@@ -84,6 +87,8 @@ namespace signalr
                     throw errors;
                 }
             }
+
+            return signal;
         }
 
         void reset()

--- a/src/signalrclient/connection.cpp
+++ b/src/signalrclient/connection.cpp
@@ -6,16 +6,27 @@
 #include "signalrclient/connection.h"
 #include "signalrclient/transport_type.h"
 #include "connection_impl.h"
+#include "completion_event.h"
 
 namespace signalr
 {
-    connection::connection(const std::string& url, trace_level trace_level, std::shared_ptr<log_writer> log_writer)
-        : m_pImpl(connection_impl::create(url, trace_level, std::move(log_writer)))
+    connection::connection(const std::string& url, trace_level trace_level, std::shared_ptr<log_writer> log_writer,
+        std::function<std::shared_ptr<http_client>(const signalr_client_config&)> http_client_factory,
+        std::function<std::shared_ptr<websocket_client>(const signalr_client_config&)> websocket_factory, bool skip_negotiation)
+        : m_pImpl(connection_impl::create(url, trace_level, std::move(log_writer), http_client_factory, websocket_factory, skip_negotiation))
     {}
 
     // Do NOT remove this destructor. Letting the compiler generate and inline the default dtor may lead to
     // undefinded behavior since we are using an incomplete type. More details here:  http://herbsutter.com/gotw/_100/
-    connection::~connection() = default;
+    connection::~connection()
+    {
+        completion_event completion;
+        m_pImpl->stop([completion](std::exception_ptr) mutable
+            {
+                completion.set();
+            }, nullptr);
+        completion.get();
+    }
 
     void connection::start(std::function<void(std::exception_ptr)> callback) noexcept
     {

--- a/src/signalrclient/hub_connection.cpp
+++ b/src/signalrclient/hub_connection.cpp
@@ -31,7 +31,15 @@ namespace signalr
 
     // Do NOT remove this destructor. Letting the compiler generate and inline the default dtor may lead to
     // undefined behavior since we are using an incomplete type. More details here:  http://herbsutter.com/gotw/_100/
-    hub_connection::~hub_connection() = default;
+    hub_connection::~hub_connection()
+    {
+        completion_event completion;
+        m_pImpl->stop([completion](std::exception_ptr) mutable
+            {
+                completion.set();
+            });
+        completion.get();
+    }
 
     void hub_connection::start(std::function<void(std::exception_ptr)> callback) noexcept
     {

--- a/src/signalrclient/hub_connection_impl.cpp
+++ b/src/signalrclient/hub_connection_impl.cpp
@@ -38,11 +38,11 @@ namespace signalr
     hub_connection_impl::hub_connection_impl(const std::string& url, std::unique_ptr<hub_protocol>&& hub_protocol, trace_level trace_level,
         const std::shared_ptr<log_writer>& log_writer, std::function<std::shared_ptr<http_client>(const signalr_client_config&)> http_client_factory,
         std::function<std::shared_ptr<websocket_client>(const signalr_client_config&)> websocket_factory, const bool skip_negotiation)
-        : m_connection(connection_impl::create(url, trace_level, log_writer,
-            http_client_factory, websocket_factory, skip_negotiation)), m_logger(log_writer, trace_level),
+        : m_connection(std::shared_ptr<connection>(new connection(url, trace_level, log_writer, http_client_factory, websocket_factory, skip_negotiation)))
+            , m_logger(log_writer, trace_level),
         m_callback_manager("connection went out of scope before invocation result was received"),
         m_handshakeReceived(false), m_disconnected([](std::exception_ptr) noexcept {}), m_protocol(std::move(hub_protocol))
-    {}
+    { }
 
     void hub_connection_impl::initialize()
     {

--- a/src/signalrclient/hub_connection_impl.h
+++ b/src/signalrclient/hub_connection_impl.h
@@ -5,12 +5,14 @@
 #pragma once
 
 #include <unordered_map>
-#include "connection_impl.h"
 #include "callback_manager.h"
 #include "case_insensitive_comparison_utils.h"
 #include "completion_event.h"
 #include "signalrclient/signalr_value.h"
 #include "hub_protocol.h"
+#include "signalrclient/connection.h"
+#include "logger.h"
+#include "cancellation_token_source.h"
 
 namespace signalr
 {
@@ -51,7 +53,7 @@ namespace signalr
             std::function<std::shared_ptr<websocket_client>(const signalr_client_config&)> websocket_factory,
             bool skip_negotiation);
 
-        std::shared_ptr<connection_impl> m_connection;
+        std::shared_ptr<connection> m_connection;
         logger m_logger;
         callback_manager m_callback_manager;
         std::unordered_map<std::string, std::function<void(const std::vector<signalr::value>&)>, case_insensitive_hash, case_insensitive_equals> m_subscriptions;

--- a/src/signalrclient/websocket_transport.h
+++ b/src/signalrclient/websocket_transport.h
@@ -46,6 +46,7 @@ namespace signalr
         signalr_client_config m_signalr_client_config;
 
         std::shared_ptr<cancellation_token_source> m_receive_loop_cts;
+        std::shared_ptr<cancellation_token_source> m_receive_loop_done_cts;
 
         void receive_loop(std::shared_ptr<cancellation_token_source> cts);
 

--- a/test/signalrclienttests/cancellation_token_source_tests.cpp
+++ b/test/signalrclienttests/cancellation_token_source_tests.cpp
@@ -35,6 +35,20 @@ TEST(cancellation_token_source, cancel_sets_canceled)
     ASSERT_TRUE(cts.is_canceled());
 }
 
+TEST(cancellation_token_source, cancel_returns_true)
+{
+    cancellation_token_source cts;
+    ASSERT_TRUE(cts.cancel());
+}
+
+TEST(cancellation_token_source, cancel_returns_false_if_already_canceled)
+{
+    cancellation_token_source cts;
+    cts.cancel();
+    ASSERT_FALSE(cts.cancel());
+    ASSERT_TRUE(cts.is_canceled());
+}
+
 TEST(cancellation_token_source, can_be_reset)
 {
     cancellation_token_source cts;

--- a/test/signalrclienttests/hub_connection_tests.cpp
+++ b/test/signalrclienttests/hub_connection_tests.cpp
@@ -727,7 +727,7 @@ TEST(stop, connection_stopped_when_going_out_of_scope)
     // The underlying connection_impl will be destroyed when the last reference to shared_ptr holding is released. This can happen
     // on a different thread in which case the dtor will be invoked on a different thread so we need to wait for this
     // to happen and if it does not the test will fail. There is nothing we can block on.
-    for (int wait_time_ms = 5; wait_time_ms < 6000 && memory_writer->get_log_entries().size() < 9; wait_time_ms <<= 1)
+    for (int wait_time_ms = 5; wait_time_ms < 6000 && memory_writer->get_log_entries().size() < 8; wait_time_ms <<= 1)
     {
         std::this_thread::sleep_for(std::chrono::milliseconds(wait_time_ms));
     }
@@ -814,7 +814,7 @@ TEST(stop, pending_callbacks_finished_if_hub_connections_goes_out_of_scope)
     }
     catch (const signalr_exception& e)
     {
-        ASSERT_STREQ("connection went out of scope before invocation result was received", e.what());
+        ASSERT_STREQ("connection was stopped before invocation result was received", e.what());
     }
 }
 


### PR DESCRIPTION
Replaces https://github.com/aspnet/SignalR-Client-Cpp/pull/71 and https://github.com/aspnet/SignalR-Client-Cpp/pull/72

* Use weak_ptr in a couple places to avoid potential cyclical references
* Wait for the websocket receive loop to be done before finishing stop
* Change the destructors of hub_connection and connection to call stop so we can avoid issues with relying on shared_ptrs of the underlying implementations to be released and instead control when and where stop is called