### PR TITLE
Prefer C++ casts over C casts

### DIFF
--- a/src/signalrclient/json_hub_protocol.cpp
+++ b/src/signalrclient/json_hub_protocol.cpp
@@ -21,7 +21,7 @@ namespace signalr
         case message_type::invocation:
         {
             auto invocation = static_cast<invocation_message const*>(hub_message);
-            object["type"] = (int)invocation->message_type;
+            object["type"] = static_cast<int>(invocation->message_type);
             if (!invocation->invocation_id.empty())
             {
                 object["invocationId"] = invocation->invocation_id;
@@ -35,7 +35,7 @@ namespace signalr
         case message_type::completion:
         {
             auto completion = static_cast<completion_message const*>(hub_message);
-            object["type"] = (int)completion->message_type;
+            object["type"] = static_cast<int>(completion->message_type);
             object["invocationId"] = completion->invocation_id;
             if (!completion->error.empty())
             {
@@ -50,7 +50,7 @@ namespace signalr
         case message_type::ping:
         {
             auto ping = static_cast<ping_message const*>(hub_message);
-            object["type"] = (int)ping->message_type;
+            object["type"] = static_cast<int>(ping->message_type);
             break;
         }
         // TODO: other message types
@@ -112,7 +112,7 @@ namespace signalr
 #pragma warning (push)
         // not all cases handled (we have a default so it's fine)
 #pragma warning (disable: 4061)
-        switch ((message_type)found->second.as_double())
+        switch (static_cast<message_type>(static_cast<int>(found->second.as_double())))
         {
         case message_type::invocation:
         {
@@ -125,7 +125,6 @@ namespace signalr
             {
                 throw signalr_exception("Expected 'target' to be of type 'string'");
             }
-
 
             found = obj.find("arguments");
             if (found == obj.end())

--- a/src/signalrclient/messagepack_hub_protocol.cpp
+++ b/src/signalrclient/messagepack_hub_protocol.cpp
@@ -119,7 +119,7 @@ namespace signalr
                     if (value <= (double)UINT64_MAX)
                     {
                         // Fits within uint64_t
-                        packer.pack_uint64((uint64_t)intPart);
+                        packer.pack_uint64(static_cast<uint64_t>(intPart));
                         return;
                     }
                     else
@@ -136,14 +136,14 @@ namespace signalr
         case signalr::value_type::string:
         {
             auto length = v.as_string().length();
-            packer.pack_str((uint32_t)length);
-            packer.pack_str_body(v.as_string().data(), (uint32_t)length);
+            packer.pack_str(static_cast<uint32_t>(length));
+            packer.pack_str_body(v.as_string().data(), static_cast<uint32_t>(length));
             return;
         }
         case signalr::value_type::array:
         {
             const auto& array = v.as_array();
-            packer.pack_array((uint32_t)array.size());
+            packer.pack_array(static_cast<uint32_t>(array.size()));
             for (auto& val : array)
             {
                 pack_messagepack(val, packer);
@@ -153,11 +153,11 @@ namespace signalr
         case signalr::value_type::map:
         {
             const auto& obj = v.as_map();
-            packer.pack_map((uint32_t)obj.size());
+            packer.pack_map(static_cast<uint32_t>(obj.size()));
             for (auto& val : obj)
             {
-                packer.pack_str((uint32_t)val.first.size());
-                packer.pack_str_body(val.first.data(), (uint32_t)val.first.size());
+                packer.pack_str(static_cast<uint32_t>(val.first.size()));
+                packer.pack_str_body(val.first.data(), static_cast<uint32_t>(val.first.size()));
                 pack_messagepack(val.second, packer);
             }
             return;
@@ -165,8 +165,8 @@ namespace signalr
         case signalr::value_type::binary:
         {
             const auto& bin = v.as_binary();
-            packer.pack_bin((uint32_t)bin.size());
-            packer.pack_bin_body((char*)bin.data(), (uint32_t)bin.size());
+            packer.pack_bin(static_cast<uint32_t>(bin.size()));
+            packer.pack_bin_body(reinterpret_cast<const char*>(bin.data()), static_cast<uint32_t>(bin.size()));
             return;
         }
         case signalr::value_type::null:
@@ -193,7 +193,7 @@ namespace signalr
 
             packer.pack_array(6);
 
-            packer.pack_int((int)message_type::invocation);
+            packer.pack_int(static_cast<int>(message_type::invocation));
             // Headers
             packer.pack_map(0);
 
@@ -203,14 +203,14 @@ namespace signalr
             }
             else
             {
-                packer.pack_str((uint32_t)invocation->invocation_id.length());
-                packer.pack_str_body(invocation->invocation_id.data(), (uint32_t)invocation->invocation_id.length());
+                packer.pack_str(static_cast<uint32_t>(invocation->invocation_id.length()));
+                packer.pack_str_body(invocation->invocation_id.data(), static_cast<uint32_t>(invocation->invocation_id.length()));
             }
 
-            packer.pack_str((uint32_t)invocation->target.length());
-            packer.pack_str_body(invocation->target.data(), (uint32_t)invocation->target.length());
+            packer.pack_str(static_cast<uint32_t>(invocation->target.length()));
+            packer.pack_str_body(invocation->target.data(), static_cast<uint32_t>(invocation->target.length()));
 
-            packer.pack_array((uint32_t)invocation->arguments.size());
+            packer.pack_array(static_cast<uint32_t>(invocation->arguments.size()));
             for (auto& val : invocation->arguments)
             {
                 pack_messagepack(val, packer);
@@ -228,21 +228,21 @@ namespace signalr
             size_t result_kind = completion->error.empty() ? (completion->has_result ? 3U : 2U) : 1U;
             packer.pack_array(4U + (result_kind != 2U ? 1U : 0U));
 
-            packer.pack_int((int)message_type::completion);
+            packer.pack_int(static_cast<int>(message_type::completion));
 
             // Headers
             packer.pack_map(0);
 
-            packer.pack_str((uint32_t)completion->invocation_id.length());
-            packer.pack_str_body(completion->invocation_id.data(), (uint32_t)completion->invocation_id.length());
+            packer.pack_str(static_cast<uint32_t>(completion->invocation_id.length()));
+            packer.pack_str_body(completion->invocation_id.data(), static_cast<uint32_t>(completion->invocation_id.length()));
 
-            packer.pack_int((int)result_kind);
+            packer.pack_int(static_cast<int>(result_kind));
             switch (result_kind)
             {
             // error result
             case 1:
-                packer.pack_str((uint32_t)completion->error.length());
-                packer.pack_str_body(completion->error.data(), (uint32_t)completion->error.length());
+                packer.pack_str(static_cast<uint32_t>(completion->error.length()));
+                packer.pack_str_body(completion->error.data(), static_cast<uint32_t>(completion->error.length()));
                 break;
             // non-void result
             case 3:
@@ -258,7 +258,7 @@ namespace signalr
             // auto ping = static_cast<ping_message const*>(hub_message);
 
             packer.pack_array(1);
-            packer.pack_int((int)message_type::ping);
+            packer.pack_int(static_cast<int>(message_type::ping));
 
             break;
         }
@@ -321,7 +321,7 @@ namespace signalr
 
 #pragma warning (push)
 #pragma warning (disable: 4061)
-            switch ((message_type)type)
+            switch (static_cast<message_type>(type))
             {
             case message_type::invocation:
             {


### PR DESCRIPTION
There is a [bug in the VS 2017 compiler](https://developercommunity.visualstudio.com/t/the-compiler-emits-c2440-when-trying-to-static-cas/793475) that doesn't allow casting a double cast to an enum.

Plus C++ casts should be preferred over C casts as they provide better compile time type safety.

There might be casts I missed since there isn't a "find C casts" search (without coming up with a regex). But I did a quick scan of the protocol class which were the main culprits, and fixed the VS 2017 issue reported by PlayFab.