### PR TITLE
default_http_client is not using specified proxy

### DIFF
--- a/src/signalrclient/connection_impl.cpp
+++ b/src/signalrclient/connection_impl.cpp
@@ -39,7 +39,7 @@ namespace signalr
         else
         {
 #ifdef USE_CPPRESTSDK
-            m_http_client_factory = [](const signalr_client_config&) { return std::unique_ptr<class http_client>(new default_http_client()); };
+            m_http_client_factory = [](const signalr_client_config& signalr_client_config) { return std::unique_ptr<class http_client>(new default_http_client(signalr_client_config)); };
 #endif
         }
 

--- a/src/signalrclient/default_http_client.cpp
+++ b/src/signalrclient/default_http_client.cpp
@@ -14,7 +14,6 @@
 
 namespace signalr
 {
-
     default_http_client::default_http_client(const signalr_client_config& config) noexcept
        : m_config(config) 
     { }

--- a/src/signalrclient/default_http_client.cpp
+++ b/src/signalrclient/default_http_client.cpp
@@ -14,6 +14,11 @@
 
 namespace signalr
 {
+
+    default_http_client::default_http_client(const signalr_client_config& config) noexcept
+       : m_config(config) 
+    { }
+
     void default_http_client::send(const std::string& url, http_request& request,
         std::function<void(const http_response&, std::exception_ptr)> callback, cancellation_token token)
     {
@@ -82,7 +87,7 @@ namespace signalr
                 cts.cancel();
             });
 
-        web::http::client::http_client client(utility::conversions::to_string_t(url));
+        web::http::client::http_client client(utility::conversions::to_string_t(url), m_config.get_http_client_config());
         client.request(http_request, cts.get_token())
             .then([context, callback](pplx::task<web::http::http_response> response_task)
         {

--- a/src/signalrclient/default_http_client.h
+++ b/src/signalrclient/default_http_client.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "signalrclient/signalr_client_config.h"
 #include "signalrclient/http_client.h"
 
 namespace signalr
@@ -11,7 +12,12 @@ namespace signalr
     class default_http_client : public http_client
     {
     public:
+       explicit default_http_client(const signalr_client_config& config = {}) noexcept;
+
         void send(const std::string& url, http_request& request,
             std::function<void(const http_response&, std::exception_ptr)> callback, cancellation_token token) override;
+
+    private:
+       signalr_client_config m_config;
     };
 }


### PR DESCRIPTION
i am using signalr-client-cpp in a project where the host can only connect through http-proxy. 

Before the ws-connection is established a http-connection is used to check the capabilities of the remote service. This connection did not use the specified proxy-configuration.