### PR TITLE
Properly handle unknown hub message types

### DIFF
--- a/src/signalrclient/hub_connection_impl.cpp
+++ b/src/signalrclient/hub_connection_impl.cpp
@@ -367,7 +367,7 @@ namespace signalr
                 // Protocol received an unknown message type and gave us a null object, safe to ignore
                 if (val == nullptr)
                 {
-                    continue;
+                    throw std::runtime_error("unknown message received");
                 }
 
                 switch (val->message_type)
@@ -418,7 +418,7 @@ namespace signalr
         {
             if (m_logger.is_enabled(trace_level::error))
             {
-                m_logger.log(trace_level::error, std::string("error occured when parsing response: ")
+                m_logger.log(trace_level::error, std::string("error occurred when parsing response: ")
                     .append(e.what())
                     .append(". response: ")
                     .append(response));

--- a/src/signalrclient/hub_connection_impl.cpp
+++ b/src/signalrclient/hub_connection_impl.cpp
@@ -364,7 +364,7 @@ namespace signalr
 
             for (const auto& val : messages)
             {
-                // Protocol received an unknown message type and gave us a null object, safe to ignore
+                // Protocol received an unknown message type and gave us a null object, close the connection like we do in other client implementations
                 if (val == nullptr)
                 {
                     throw std::runtime_error("unknown message received");
@@ -410,6 +410,9 @@ namespace signalr
                     break;
                 case message_type::close:
                     // TODO
+                    break;
+                default:
+                    throw std::runtime_error("unknown message type '" + std::to_string(static_cast<int>(val->message_type)) + "' received");
                     break;
                 }
             }

--- a/src/signalrclient/hub_connection_impl.cpp
+++ b/src/signalrclient/hub_connection_impl.cpp
@@ -364,6 +364,12 @@ namespace signalr
 
             for (const auto& val : messages)
             {
+                // Protocol received an unknown message type and gave us a null object, safe to ignore
+                if (val == nullptr)
+                {
+                    continue;
+                }
+
                 switch (val->message_type)
                 {
                 case message_type::invocation:

--- a/src/signalrclient/hub_connection_impl.cpp
+++ b/src/signalrclient/hub_connection_impl.cpp
@@ -367,7 +367,7 @@ namespace signalr
                 // Protocol received an unknown message type and gave us a null object, close the connection like we do in other client implementations
                 if (val == nullptr)
                 {
-                    throw std::runtime_error("unknown message received");
+                    throw std::runtime_error("null message received");
                 }
 
                 switch (val->message_type)

--- a/src/signalrclient/json_helpers.cpp
+++ b/src/signalrclient/json_helpers.cpp
@@ -9,6 +9,8 @@
 
 namespace signalr
 {
+    extern char record_separator = '\x1e';
+
     signalr::value createValue(const Json::Value& v)
     {
         switch (v.type())

--- a/src/signalrclient/json_helpers.cpp
+++ b/src/signalrclient/json_helpers.cpp
@@ -9,7 +9,7 @@
 
 namespace signalr
 {
-    extern char record_separator = '\x1e';
+    char record_separator = '\x1e';
 
     signalr::value createValue(const Json::Value& v)
     {

--- a/src/signalrclient/json_helpers.h
+++ b/src/signalrclient/json_helpers.h
@@ -10,7 +10,7 @@
 
 namespace signalr
 {
-    static constexpr char record_separator = '\x1e';
+    extern char record_separator;
 
     signalr::value createValue(const Json::Value& v);
 

--- a/src/signalrclient/json_hub_protocol.cpp
+++ b/src/signalrclient/json_hub_protocol.cpp
@@ -70,7 +70,10 @@ namespace signalr
         while (pos != std::string::npos)
         {
             auto hub_message = parse_message(message.c_str() + offset, pos - offset);
-            vec.emplace_back(std::move(hub_message));
+            if (hub_message != nullptr)
+            {
+                vec.emplace_back(std::move(hub_message));
+            }
 
             offset = pos + 1;
             pos = message.find(record_separator, offset);

--- a/src/signalrclient/json_hub_protocol.cpp
+++ b/src/signalrclient/json_hub_protocol.cpp
@@ -72,7 +72,7 @@ namespace signalr
             auto hub_message = parse_message(message.c_str() + offset, pos - offset);
             if (hub_message != nullptr)
             {
-                vec.emplace_back(std::move(hub_message));
+                vec.push_back(std::move(hub_message));
             }
 
             offset = pos + 1;

--- a/test/signalrclienttests/hub_connection_tests.cpp
+++ b/test/signalrclienttests/hub_connection_tests.cpp
@@ -1968,7 +1968,7 @@ TEST(receive, close_connection_on_null_hub_message)
     }
     catch (const std::exception& ex)
     {
-        ASSERT_STREQ("unknown message received", ex.what());
+        ASSERT_STREQ("null message received", ex.what());
     }
 }
 

--- a/test/signalrclienttests/hub_connection_tests.cpp
+++ b/test/signalrclienttests/hub_connection_tests.cpp
@@ -1961,6 +1961,8 @@ TEST(receive, ignores_null_hub_message)
 
     websocket_client->receive_message("{ \"type\": 134 }\x1e");
     websocket_client->receive_message("{ \"type\": 1, \"arguments\": [], \"target\": \"Target\" }\x1e");
+    // blocks until previous message is fully processed
+    websocket_client->receive_message("{ \"type\": 6 }\x1e");
 
     ASSERT_TRUE(on_called);
 }

--- a/test/signalrclienttests/json_hub_protocol_tests.cpp
+++ b/test/signalrclienttests/json_hub_protocol_tests.cpp
@@ -128,6 +128,15 @@ TEST(json_hub_protocol, extra_items_ignored_when_parsing)
     assert_hub_message_equality(&message, output[0].get());
 }
 
+TEST(json_hub_protocol, unknown_message_type_returns_null)
+{
+    ping_message message = ping_message();
+    // adding ping message, just make sure other messages are still being parsed
+    auto output = json_hub_protocol().parse_messages("{\"type\":142}\x1e{\"type\":6}\x1e");
+    ASSERT_EQ(1, output.size());
+    assert_hub_message_equality(&message, output[0].get());
+}
+
 std::vector<std::pair<std::string, std::string>> invalid_messages
 {
     { "\x1e", "* Line 1, Column 1\n  Syntax error: value, object or array expected.\n* Line 1, Column 1\n  A valid JSON document must be either an array or an object value.\n" },

--- a/test/signalrclienttests/messagepack_hub_protocol_tests.cpp
+++ b/test/signalrclienttests/messagepack_hub_protocol_tests.cpp
@@ -119,6 +119,17 @@ TEST(messagepack_hub_protocol, extra_items_ignored_when_parsing)
     assert_hub_message_equality(&message, output[0].get());
 }
 
+TEST(messagepack_hub_protocol, unknown_message_type_returns_null)
+{
+    ping_message message = ping_message();
+    auto payload = string_from_bytes({ 0x04, 0x93, 0x6E, 0x80, 0xC0,
+        // adding ping message, just make sure other messages are still being parsed
+        0x02, 0x91, 0x06 });
+    auto output = messagepack_hub_protocol().parse_messages(payload);
+    ASSERT_EQ(1, output.size());
+    assert_hub_message_equality(&message, output[0].get());
+}
+
 namespace
 {
     std::vector<std::pair<std::string, std::string>> invalid_messages


### PR DESCRIPTION
Technically just the change in hub_connection_impl is enough, but why not also stop our protocol impls from returning a null message as well.