### PR TITLE
Fix exception message

### DIFF
--- a/src/signalrclient/hub_connection_impl.cpp
+++ b/src/signalrclient/hub_connection_impl.cpp
@@ -96,7 +96,7 @@ namespace signalr
         auto connection = weak_connection.lock();
         if (connection && connection->get_connection_state() != connection_state::disconnected)
         {
-            throw signalr_exception("can't register a handler if the connection is in a disconnected state");
+            throw signalr_exception("can't register a handler if the connection is not in a disconnected state");
         }
 
         if (m_subscriptions.find(event_name) != m_subscriptions.end())

--- a/test/signalrclienttests/hub_connection_tests.cpp
+++ b/test/signalrclienttests/hub_connection_tests.cpp
@@ -1627,7 +1627,7 @@ TEST(on, cannot_register_handler_if_connection_not_in_disconnected_state)
     }
     catch (const signalr_exception& e)
     {
-        ASSERT_STREQ("can't register a handler if the connection is in a disconnected state", e.what());
+        ASSERT_STREQ("can't register a handler if the connection is not in a disconnected state", e.what());
     }
 }
 


### PR DESCRIPTION
 Is the exception that should throw "can't register a handler if the connection is _**not**_ in a disconnected state"?