### PR TITLE
Fix CI: use vcpkg-providing images and simplify VCPKG_ROOT setup

### DIFF
--- a/.azure/default-build.yml
+++ b/.azure/default-build.yml
@@ -28,7 +28,7 @@ jobs:
           vmImage: ubuntu-latest
         ${{ if eq(parameters.agentOs, 'Windows') }}:
           name: $(DncEngPublicBuildPool)
-          image: windows.vs2026.amd64.open
+          image: 1es-windows-2022-open
           os: windows
       steps:
       - checkout: self
@@ -92,7 +92,7 @@ jobs:
           os: linux
         ${{ if eq(parameters.agentOs, 'Windows') }}:
           name: $(DncEngInternalBuildPool)
-          image: windows.vs2026.amd64
+          image: 1es-windows-2022
           os: windows
       steps:
       - checkout: self

--- a/azure-pipelines-public.yml
+++ b/azure-pipelines-public.yml
@@ -33,16 +33,8 @@ stages:
       cMakeRunArgs: '-A x64'
       beforeBuild:
       - powershell: |
-          $vcpkgRoot = $env:VCPKG_ROOT
-          if (-not $vcpkgRoot -and $env:VCPKG_INSTALLATION_ROOT) { $vcpkgRoot = $env:VCPKG_INSTALLATION_ROOT }
-          if (-not $vcpkgRoot) {
-            $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
-            $vsPath = & $vswhere -latest -prerelease -property installationPath
-            if ($vsPath) { $vcpkgRoot = Join-Path $vsPath 'VC\vcpkg' }
-          }
-          if (-not $vcpkgRoot -or -not (Test-Path $vcpkgRoot)) { Write-Error "Could not locate vcpkg"; exit 1 }
-          if (-not (Test-Path (Join-Path $vcpkgRoot 'vcpkg.exe'))) { & (Join-Path $vcpkgRoot 'bootstrap-vcpkg.bat') }
-          Write-Host "##vso[task.setvariable variable=VCPKG_ROOT]$vcpkgRoot"
+          $root = if ($env:VCPKG_ROOT) { $env:VCPKG_ROOT } else { $env:VCPKG_INSTALLATION_ROOT }
+          Write-Host "##vso[task.setvariable variable=VCPKG_ROOT]$root"
         displayName: Set VCPKG_ROOT
       - powershell: '& "$env:VCPKG_ROOT\vcpkg.exe" install cpprestsdk:x64-windows msgpack:x64-windows jsoncpp:x64-windows'
         displayName: vcpkg install dependencies
@@ -92,16 +84,8 @@ stages:
       cMakeRunArgs: '-A x64'
       beforeBuild:
       - powershell: |
-          $vcpkgRoot = $env:VCPKG_ROOT
-          if (-not $vcpkgRoot -and $env:VCPKG_INSTALLATION_ROOT) { $vcpkgRoot = $env:VCPKG_INSTALLATION_ROOT }
-          if (-not $vcpkgRoot) {
-            $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
-            $vsPath = & $vswhere -latest -prerelease -property installationPath
-            if ($vsPath) { $vcpkgRoot = Join-Path $vsPath 'VC\vcpkg' }
-          }
-          if (-not $vcpkgRoot -or -not (Test-Path $vcpkgRoot)) { Write-Error "Could not locate vcpkg"; exit 1 }
-          if (-not (Test-Path (Join-Path $vcpkgRoot 'vcpkg.exe'))) { & (Join-Path $vcpkgRoot 'bootstrap-vcpkg.bat') }
-          Write-Host "##vso[task.setvariable variable=VCPKG_ROOT]$vcpkgRoot"
+          $root = if ($env:VCPKG_ROOT) { $env:VCPKG_ROOT } else { $env:VCPKG_INSTALLATION_ROOT }
+          Write-Host "##vso[task.setvariable variable=VCPKG_ROOT]$root"
         displayName: Set VCPKG_ROOT
       - powershell: '& "$env:VCPKG_ROOT\vcpkg.exe" install msgpack:x64-windows jsoncpp:x64-windows'
         displayName: vcpkg install dependencies

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,16 +63,8 @@ extends:
           cMakeRunArgs: '-A x64'
           beforeBuild:
           - powershell: |
-              $vcpkgRoot = $env:VCPKG_ROOT
-              if (-not $vcpkgRoot -and $env:VCPKG_INSTALLATION_ROOT) { $vcpkgRoot = $env:VCPKG_INSTALLATION_ROOT }
-              if (-not $vcpkgRoot) {
-                $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
-                $vsPath = & $vswhere -latest -prerelease -property installationPath
-                if ($vsPath) { $vcpkgRoot = Join-Path $vsPath 'VC\vcpkg' }
-              }
-              if (-not $vcpkgRoot -or -not (Test-Path $vcpkgRoot)) { Write-Error "Could not locate vcpkg"; exit 1 }
-              if (-not (Test-Path (Join-Path $vcpkgRoot 'vcpkg.exe'))) { & (Join-Path $vcpkgRoot 'bootstrap-vcpkg.bat') }
-              Write-Host "##vso[task.setvariable variable=VCPKG_ROOT]$vcpkgRoot"
+              $root = if ($env:VCPKG_ROOT) { $env:VCPKG_ROOT } else { $env:VCPKG_INSTALLATION_ROOT }
+              Write-Host "##vso[task.setvariable variable=VCPKG_ROOT]$root"
             displayName: Set VCPKG_ROOT
           - powershell: '& "$env:VCPKG_ROOT\vcpkg.exe" install cpprestsdk:x64-windows msgpack:x64-windows jsoncpp:x64-windows'
             displayName: vcpkg install dependencies
@@ -94,6 +86,8 @@ extends:
           jobName: Linux_Build_Test_With_CppRestSDK
           useCppRestSDK: true
           beforeBuild:
+          - bash: echo "##vso[task.setvariable variable=VCPKG_ROOT]$VCPKG_INSTALLATION_ROOT"
+            displayName: Set VCPKG_ROOT
           - bash: '"$VCPKG_ROOT/vcpkg" install cpprestsdk boost-system boost-chrono boost-thread msgpack jsoncpp'
             displayName: vcpkg install dependencies
           - bash: "sudo apt-get update && sudo apt install valgrind"
@@ -105,6 +99,8 @@ extends:
           jobName: Linux_Build_Test
           useCppRestSDK: false
           beforeBuild:
+          - bash: echo "##vso[task.setvariable variable=VCPKG_ROOT]$VCPKG_INSTALLATION_ROOT"
+            displayName: Set VCPKG_ROOT
           - bash: '"$VCPKG_ROOT/vcpkg" install msgpack jsoncpp'
             displayName: vcpkg install dependencies
           - bash: "sudo apt-get update && sudo apt install valgrind"
@@ -118,16 +114,8 @@ extends:
           cMakeRunArgs: '-A x64'
           beforeBuild:
           - powershell: |
-              $vcpkgRoot = $env:VCPKG_ROOT
-              if (-not $vcpkgRoot -and $env:VCPKG_INSTALLATION_ROOT) { $vcpkgRoot = $env:VCPKG_INSTALLATION_ROOT }
-              if (-not $vcpkgRoot) {
-                $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
-                $vsPath = & $vswhere -latest -prerelease -property installationPath
-                if ($vsPath) { $vcpkgRoot = Join-Path $vsPath 'VC\vcpkg' }
-              }
-              if (-not $vcpkgRoot -or -not (Test-Path $vcpkgRoot)) { Write-Error "Could not locate vcpkg"; exit 1 }
-              if (-not (Test-Path (Join-Path $vcpkgRoot 'vcpkg.exe'))) { & (Join-Path $vcpkgRoot 'bootstrap-vcpkg.bat') }
-              Write-Host "##vso[task.setvariable variable=VCPKG_ROOT]$vcpkgRoot"
+              $root = if ($env:VCPKG_ROOT) { $env:VCPKG_ROOT } else { $env:VCPKG_INSTALLATION_ROOT }
+              Write-Host "##vso[task.setvariable variable=VCPKG_ROOT]$root"
             displayName: Set VCPKG_ROOT
           - powershell: '& "$env:VCPKG_ROOT\vcpkg.exe" install msgpack:x64-windows jsoncpp:x64-windows'
             displayName: vcpkg install dependencies


### PR DESCRIPTION
Follow-up to #113. The internal build failed because the vs2026 Windows images and the VS-bundled vcpkg fallback don't provide a classic-mode vcpkg, and the internal Linux jobs were missing the `Set VCPKG_ROOT` step.

## Changes
- **Windows images** → `1es-windows-2022` (internal) / `1es-windows-2022-open` (public). These mirror the Microsoft-hosted windows-2022 runner and ship a classic-mode vcpkg at `VCPKG_INSTALLATION_ROOT`. This reverts the vs2026 bump, since no vcpkg-providing image ships VS 2026.
- **Simplify Windows `Set VCPKG_ROOT` step** to use `VCPKG_ROOT` else `VCPKG_INSTALLATION_ROOT`. Dropped the `vswhere`/VS-bundled-vcpkg fallback, which resolved to a manifest-mode-only vcpkg and caused `"This vcpkg distribution does not have a classic mode instance."`
- **Add missing `Set VCPKG_ROOT` step** to both internal Linux jobs (`Linux_Build_Test_With_CppRestSDK`, `Linux_Build_Test`), which were failing with `/vcpkg: No such file or directory`.

macOS (`macOS-latest`) and Linux (`1es-ubuntu-2204`) images are unchanged.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>