### PR TITLE
Fix cpprestsdk vcpkg break via manifest mode baseline pin

### DIFF
--- a/.azure/default-build.yml
+++ b/.azure/default-build.yml
@@ -42,12 +42,12 @@ jobs:
       # restore can resolve the baseline and the removed port from history.
       - ${{ if eq(parameters.agentOs, 'Windows') }}:
         - powershell: |
-            git -C "$env:VCPKG_ROOT" fetch --unshallow origin 2>$null
             git -C "$env:VCPKG_ROOT" fetch origin fa9a5b330aed997a68310ed56418617b87a3b83d
+            if ($LASTEXITCODE -ne 0) { throw "Failed to fetch vcpkg baseline" }
+          errorActionPreference: continue
           displayName: Fetch vcpkg baseline
       - ${{ if ne(parameters.agentOs, 'Windows') }}:
         - bash: |
-            git -C "$VCPKG_ROOT" fetch --unshallow origin 2>/dev/null || true
             git -C "$VCPKG_ROOT" fetch origin fa9a5b330aed997a68310ed56418617b87a3b83d
           displayName: Fetch vcpkg baseline
 
@@ -125,12 +125,12 @@ jobs:
       # restore can resolve the baseline and the removed port from history.
       - ${{ if eq(parameters.agentOs, 'Windows') }}:
         - powershell: |
-            git -C "$env:VCPKG_ROOT" fetch --unshallow origin 2>$null
             git -C "$env:VCPKG_ROOT" fetch origin fa9a5b330aed997a68310ed56418617b87a3b83d
+            if ($LASTEXITCODE -ne 0) { throw "Failed to fetch vcpkg baseline" }
+          errorActionPreference: continue
           displayName: Fetch vcpkg baseline
       - ${{ if ne(parameters.agentOs, 'Windows') }}:
         - bash: |
-            git -C "$VCPKG_ROOT" fetch --unshallow origin 2>/dev/null || true
             git -C "$VCPKG_ROOT" fetch origin fa9a5b330aed997a68310ed56418617b87a3b83d
           displayName: Fetch vcpkg baseline
 

--- a/.azure/default-build.yml
+++ b/.azure/default-build.yml
@@ -36,21 +36,6 @@ jobs:
 
       - ${{ parameters.beforeBuild }}
 
-      # The machine-provided vcpkg is a shallow clone that may not contain the
-      # builtin-baseline pinned in vcpkg.json (cpprestsdk was deindexed from tip,
-      # so we pin to the commit before its removal). Deepen the clone so manifest
-      # restore can resolve the baseline and the removed port from history.
-      - ${{ if eq(parameters.agentOs, 'Windows') }}:
-        - powershell: |
-            git -C "$env:VCPKG_ROOT" fetch origin fa9a5b330aed997a68310ed56418617b87a3b83d
-            if ($LASTEXITCODE -ne 0) { throw "Failed to fetch vcpkg baseline" }
-          errorActionPreference: continue
-          displayName: Fetch vcpkg baseline
-      - ${{ if ne(parameters.agentOs, 'Windows') }}:
-        - bash: |
-            git -C "$VCPKG_ROOT" fetch origin fa9a5b330aed997a68310ed56418617b87a3b83d
-          displayName: Fetch vcpkg baseline
-
       - task: CMake@1
         inputs:
           cmakeArgs: .. ${{ parameters.cMakeRunArgs }} -DCMAKE_BUILD_TYPE=${{ parameters.configuration }} -DUSE_CPPRESTSDK=${{ parameters.useCppRestSDK }} -DUSE_MSGPACK=true
@@ -118,21 +103,6 @@ jobs:
           displayName: Install native dependencies
 
       - ${{ parameters.beforeBuild }}
-
-      # The machine-provided vcpkg is a shallow clone that may not contain the
-      # builtin-baseline pinned in vcpkg.json (cpprestsdk was deindexed from tip,
-      # so we pin to the commit before its removal). Deepen the clone so manifest
-      # restore can resolve the baseline and the removed port from history.
-      - ${{ if eq(parameters.agentOs, 'Windows') }}:
-        - powershell: |
-            git -C "$env:VCPKG_ROOT" fetch origin fa9a5b330aed997a68310ed56418617b87a3b83d
-            if ($LASTEXITCODE -ne 0) { throw "Failed to fetch vcpkg baseline" }
-          errorActionPreference: continue
-          displayName: Fetch vcpkg baseline
-      - ${{ if ne(parameters.agentOs, 'Windows') }}:
-        - bash: |
-            git -C "$VCPKG_ROOT" fetch origin fa9a5b330aed997a68310ed56418617b87a3b83d
-          displayName: Fetch vcpkg baseline
 
       - task: CMake@1
         inputs:

--- a/.azure/default-build.yml
+++ b/.azure/default-build.yml
@@ -36,6 +36,21 @@ jobs:
 
       - ${{ parameters.beforeBuild }}
 
+      # The machine-provided vcpkg is a shallow clone that may not contain the
+      # builtin-baseline pinned in vcpkg.json (cpprestsdk was deindexed from tip,
+      # so we pin to the commit before its removal). Deepen the clone so manifest
+      # restore can resolve the baseline and the removed port from history.
+      - ${{ if eq(parameters.agentOs, 'Windows') }}:
+        - powershell: |
+            git -C "$env:VCPKG_ROOT" fetch --unshallow origin 2>$null
+            git -C "$env:VCPKG_ROOT" fetch origin fa9a5b330aed997a68310ed56418617b87a3b83d
+          displayName: Fetch vcpkg baseline
+      - ${{ if ne(parameters.agentOs, 'Windows') }}:
+        - bash: |
+            git -C "$VCPKG_ROOT" fetch --unshallow origin 2>/dev/null || true
+            git -C "$VCPKG_ROOT" fetch origin fa9a5b330aed997a68310ed56418617b87a3b83d
+          displayName: Fetch vcpkg baseline
+
       - task: CMake@1
         inputs:
           cmakeArgs: .. ${{ parameters.cMakeRunArgs }} -DCMAKE_BUILD_TYPE=${{ parameters.configuration }} -DUSE_CPPRESTSDK=${{ parameters.useCppRestSDK }} -DUSE_MSGPACK=true
@@ -103,6 +118,21 @@ jobs:
           displayName: Install native dependencies
 
       - ${{ parameters.beforeBuild }}
+
+      # The machine-provided vcpkg is a shallow clone that may not contain the
+      # builtin-baseline pinned in vcpkg.json (cpprestsdk was deindexed from tip,
+      # so we pin to the commit before its removal). Deepen the clone so manifest
+      # restore can resolve the baseline and the removed port from history.
+      - ${{ if eq(parameters.agentOs, 'Windows') }}:
+        - powershell: |
+            git -C "$env:VCPKG_ROOT" fetch --unshallow origin 2>$null
+            git -C "$env:VCPKG_ROOT" fetch origin fa9a5b330aed997a68310ed56418617b87a3b83d
+          displayName: Fetch vcpkg baseline
+      - ${{ if ne(parameters.agentOs, 'Windows') }}:
+        - bash: |
+            git -C "$VCPKG_ROOT" fetch --unshallow origin 2>/dev/null || true
+            git -C "$VCPKG_ROOT" fetch origin fa9a5b330aed997a68310ed56418617b87a3b83d
+          displayName: Fetch vcpkg baseline
 
       - task: CMake@1
         inputs:

--- a/azure-pipelines-public.yml
+++ b/azure-pipelines-public.yml
@@ -30,36 +30,32 @@ stages:
       agentOs: Windows
       jobName: Windows_Build_Test_With_CppRestSDK
       useCppRestSDK: true
-      cMakeRunArgs: '-A x64'
+      cMakeRunArgs: '-A x64 -DVCPKG_MANIFEST_FEATURES=cpprestsdk'
       beforeBuild:
       - powershell: |
           $root = if ($env:VCPKG_ROOT) { $env:VCPKG_ROOT } else { $env:VCPKG_INSTALLATION_ROOT }
           Write-Host "##vso[task.setvariable variable=VCPKG_ROOT]$root"
         displayName: Set VCPKG_ROOT
-      - powershell: '& "$env:VCPKG_ROOT\vcpkg.exe" install cpprestsdk:x64-windows msgpack:x64-windows jsoncpp:x64-windows'
-        displayName: vcpkg install dependencies
 
   - template: .azure/default-build.yml
     parameters:
       agentOs: macOs
       jobName: Mac_Build_Test_With_CppRestSDK
       useCppRestSDK: true
+      cMakeRunArgs: '-DVCPKG_MANIFEST_FEATURES=cpprestsdk'
       beforeBuild:
       - bash: echo "##vso[task.setvariable variable=VCPKG_ROOT]$VCPKG_INSTALLATION_ROOT"
         displayName: Set VCPKG_ROOT
-      - bash: '"$VCPKG_ROOT/vcpkg" install cpprestsdk msgpack jsoncpp'
-        displayName: vcpkg install dependencies
 
   - template: .azure/default-build.yml
     parameters:
       agentOs: Linux
       jobName: Linux_Build_Test_With_CppRestSDK
       useCppRestSDK: true
+      cMakeRunArgs: '-DVCPKG_MANIFEST_FEATURES=cpprestsdk'
       beforeBuild:
       - bash: echo "##vso[task.setvariable variable=VCPKG_ROOT]$VCPKG_INSTALLATION_ROOT"
         displayName: Set VCPKG_ROOT
-      - bash: '"$VCPKG_ROOT/vcpkg" install cpprestsdk boost-system boost-chrono boost-thread msgpack jsoncpp'
-        displayName: vcpkg install dependencies
       - bash: "sudo apt-get update && sudo apt install valgrind"
         displayName: install valgrind
 
@@ -71,8 +67,6 @@ stages:
       beforeBuild:
       - bash: echo "##vso[task.setvariable variable=VCPKG_ROOT]$VCPKG_INSTALLATION_ROOT"
         displayName: Set VCPKG_ROOT
-      - bash: '"$VCPKG_ROOT/vcpkg" install msgpack jsoncpp'
-        displayName: vcpkg install dependencies
       - bash: "sudo apt-get update && sudo apt install valgrind"
         displayName: install valgrind
 
@@ -87,8 +81,6 @@ stages:
           $root = if ($env:VCPKG_ROOT) { $env:VCPKG_ROOT } else { $env:VCPKG_INSTALLATION_ROOT }
           Write-Host "##vso[task.setvariable variable=VCPKG_ROOT]$root"
         displayName: Set VCPKG_ROOT
-      - powershell: '& "$env:VCPKG_ROOT\vcpkg.exe" install msgpack:x64-windows jsoncpp:x64-windows'
-        displayName: vcpkg install dependencies
 
   - template: .azure/default-build.yml
     parameters:
@@ -100,5 +92,3 @@ stages:
         displayName: Set VCPKG_ROOT
       - script: brew install gcc
         displayName: Install gcc
-      - bash: '"$VCPKG_ROOT/vcpkg" install msgpack jsoncpp'
-        displayName: vcpkg install dependencies

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -60,36 +60,32 @@ extends:
           agentOs: Windows
           jobName: Windows_Build_Test_With_CppRestSDK
           useCppRestSDK: true
-          cMakeRunArgs: '-A x64'
+          cMakeRunArgs: '-A x64 -DVCPKG_MANIFEST_FEATURES=cpprestsdk'
           beforeBuild:
           - powershell: |
               $root = if ($env:VCPKG_ROOT) { $env:VCPKG_ROOT } else { $env:VCPKG_INSTALLATION_ROOT }
               Write-Host "##vso[task.setvariable variable=VCPKG_ROOT]$root"
             displayName: Set VCPKG_ROOT
-          - powershell: '& "$env:VCPKG_ROOT\vcpkg.exe" install cpprestsdk:x64-windows msgpack:x64-windows jsoncpp:x64-windows'
-            displayName: vcpkg install dependencies
 
       - template: .azure/default-build.yml@self
         parameters:
           agentOs: macOs
           jobName: Mac_Build_Test_With_CppRestSDK
           useCppRestSDK: true
+          cMakeRunArgs: '-DVCPKG_MANIFEST_FEATURES=cpprestsdk'
           beforeBuild:
           - bash: echo "##vso[task.setvariable variable=VCPKG_ROOT]$VCPKG_INSTALLATION_ROOT"
             displayName: Set VCPKG_ROOT
-          - bash: '"$VCPKG_ROOT/vcpkg" install cpprestsdk msgpack jsoncpp'
-            displayName: vcpkg install dependencies
 
       - template: .azure/default-build.yml@self
         parameters:
           agentOs: Linux
           jobName: Linux_Build_Test_With_CppRestSDK
           useCppRestSDK: true
+          cMakeRunArgs: '-DVCPKG_MANIFEST_FEATURES=cpprestsdk'
           beforeBuild:
           - bash: echo "##vso[task.setvariable variable=VCPKG_ROOT]$VCPKG_INSTALLATION_ROOT"
             displayName: Set VCPKG_ROOT
-          - bash: '"$VCPKG_ROOT/vcpkg" install cpprestsdk boost-system boost-chrono boost-thread msgpack jsoncpp'
-            displayName: vcpkg install dependencies
           - bash: "sudo apt-get update && sudo apt install valgrind"
             displayName: install valgrind
 
@@ -101,8 +97,6 @@ extends:
           beforeBuild:
           - bash: echo "##vso[task.setvariable variable=VCPKG_ROOT]$VCPKG_INSTALLATION_ROOT"
             displayName: Set VCPKG_ROOT
-          - bash: '"$VCPKG_ROOT/vcpkg" install msgpack jsoncpp'
-            displayName: vcpkg install dependencies
           - bash: "sudo apt-get update && sudo apt install valgrind"
             displayName: install valgrind
 
@@ -117,8 +111,6 @@ extends:
               $root = if ($env:VCPKG_ROOT) { $env:VCPKG_ROOT } else { $env:VCPKG_INSTALLATION_ROOT }
               Write-Host "##vso[task.setvariable variable=VCPKG_ROOT]$root"
             displayName: Set VCPKG_ROOT
-          - powershell: '& "$env:VCPKG_ROOT\vcpkg.exe" install msgpack:x64-windows jsoncpp:x64-windows'
-            displayName: vcpkg install dependencies
 
       - template: .azure/default-build.yml@self
         parameters:
@@ -130,5 +122,3 @@ extends:
             displayName: Set VCPKG_ROOT
           - script: brew install gcc
             displayName: Install gcc
-          - bash: '"$VCPKG_ROOT/vcpkg" install msgpack jsoncpp'
-            displayName: vcpkg install dependencies

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,0 +1,8 @@
+{
+  "$comment": "Pin the vcpkg registry to microsoft/vcpkg fa9a5b33 (2026-06-02), the commit immediately before cpprestsdk was deindexed in microsoft/vcpkg#52130. vcpkg fetches this registry into its own cache, so resolution is independent of the machine-provided vcpkg checkout and the removed cpprestsdk port stays installable.",
+  "default-registry": {
+    "kind": "git",
+    "repository": "https://github.com/microsoft/vcpkg",
+    "baseline": "fa9a5b330aed997a68310ed56418617b87a3b83d"
+  }
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,8 +1,6 @@
 {
   "name": "microsoft-signalr",
   "version-string": "1.0",
-  "$comment": "builtin-baseline pins vcpkg to microsoft/vcpkg fa9a5b33 (2026-06-02), the commit immediately before cpprestsdk was deindexed (microsoft/vcpkg#52130). This keeps using the machine-provided vcpkg (no submodule) while still resolving the removed cpprestsdk port from the versions database. cpprestsdk is opt-in via the 'cpprestsdk' feature (enabled with -DVCPKG_MANIFEST_FEATURES=cpprestsdk).",
-  "builtin-baseline": "fa9a5b330aed997a68310ed56418617b87a3b83d",
   "dependencies": [
     "jsoncpp",
     "msgpack"

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "microsoft-signalr",
+  "version-string": "1.0",
+  "$comment": "builtin-baseline pins vcpkg to microsoft/vcpkg fa9a5b33 (2026-06-02), the commit immediately before cpprestsdk was deindexed (microsoft/vcpkg#52130). This keeps using the machine-provided vcpkg (no submodule) while still resolving the removed cpprestsdk port from the versions database. cpprestsdk is opt-in via the 'cpprestsdk' feature (enabled with -DVCPKG_MANIFEST_FEATURES=cpprestsdk).",
+  "builtin-baseline": "fa9a5b330aed997a68310ed56418617b87a3b83d",
+  "dependencies": [
+    "jsoncpp",
+    "msgpack"
+  ],
+  "features": {
+    "cpprestsdk": {
+      "description": "Build with the cpprestsdk-based HTTP/WebSocket transport",
+      "dependencies": [
+        "cpprestsdk"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Problem

CI is failing on all `*_With_CppRestSDK` legs at the `vcpkg install` step:

```
error: cpprestsdk does not exist
```

**Root cause:** `cpprestsdk` was deindexed from the vcpkg registry on 2026-06-02 in [microsoft/vcpkg#52130](https://github.com/microsoft/vcpkg/pull/52130) (commit `9ceec72e`). The Azure Pipelines agents use the machine-provided vcpkg at its tip, so classic-mode `vcpkg install cpprestsdk` can no longer find the port. This is unrelated to any repo change — it broke purely due to an upstream vcpkg update.

## Fix

Switch to **vcpkg manifest mode**, keeping the machine-provided vcpkg (no submodule, consistent with #113/#114):

- Add a `vcpkg.json` with `builtin-baseline` pinned to `fa9a5b33…` — the commit **immediately before** the deindex. At that baseline the versions database still lists `cpprestsdk` (`2.10.19#6`), so it resolves cleanly via versioning while every other dependency stays on a coherent 2026-06-02 snapshot.
- `cpprestsdk` is opt-in via a manifest **feature**, enabled only on the CppRestSDK legs with `-DVCPKG_MANIFEST_FEATURES=cpprestsdk`. The non-CppRestSDK legs install only `jsoncpp` + `msgpack`, matching prior behavior.
- Remove the explicit `vcpkg install …` steps from both pipelines — the vcpkg CMake toolchain auto-installs the manifest (into `build*/vcpkg_installed`, never the shared vcpkg root) during CMake configure. `boost-*` is dropped from the explicit list because `cpprestsdk` pulls it (and OpenSSL) transitively.

Both `azure-pipelines-public.yml` and the internal `azure-pipelines.yml` are updated identically. `Set VCPKG_ROOT`, valgrind, and gcc steps are unchanged.
