### PR TITLE
Update openssl to patched 3.6.3 (Component Governance)

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -4,5 +4,14 @@
     "kind": "git",
     "repository": "https://github.com/microsoft/vcpkg",
     "baseline": "fa9a5b330aed997a68310ed56418617b87a3b83d"
-  }
+  },
+  "$comment-registries": "Route openssl to a recent vcpkg baseline (2026-07-14) so it resolves to the patched 3.6.3 instead of the vulnerable 3.6.2 frozen by the default-registry pin. cpprestsdk (which pulls openssl transitively) still resolves via the pinned default-registry. Add 'brotli' here once a fixed release is published upstream and indexed by vcpkg.",
+  "registries": [
+    {
+      "kind": "git",
+      "repository": "https://github.com/microsoft/vcpkg",
+      "baseline": "8e8dfb4ba483886936ded5ca201b500b8d8b0096",
+      "packages": [ "openssl" ]
+    }
+  ]
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -12,5 +12,11 @@
         "cpprestsdk"
       ]
     }
-  }
+  },
+  "overrides": [
+    {
+      "name": "openssl",
+      "version": "3.6.3"
+    }
+  ]
 }


### PR DESCRIPTION
## Problem

Component Governance flags two transitive vcpkg dependencies pulled in by `cpprestsdk`:
- **openssl 3.6.2** — remediated by a release including openssl/openssl@51ea949 (backported to the 3.6.x branch)
- **brotli 1.2.0** — remediated by a release including google/brotli@3f65544

Both versions were frozen by #116, which pinned the vcpkg `default-registry` to `fa9a5b33` (2026-06-02, immediately before `cpprestsdk` was deindexed). Moving the whole baseline forward would re-break `cpprestsdk`.

## Fix

Route **openssl** through a **package-scoped registry** pinned to a recent vcpkg baseline (`8e8dfb4`, 2026-07-14), where it resolves to the patched **3.6.3**. The `default-registry` stays pinned so `cpprestsdk` still resolves; it simply builds against the newer openssl. An `overrides` floor in `vcpkg.json` pins openssl to `3.6.3` explicitly.

## brotli not addressed here

`v1.2.0` is the latest brotli release both upstream and in vcpkg; the referenced fix commit `3f65544` is not in any tagged release (unreleased). There is no upgrade target, so the brotli alert should be deferred/dismissed in CG as "no fix available" and revisited once upstream ships a patched release — at which point `brotli` can be added to the package registry's `packages` list.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>