### PR TITLE
Route vcpkg build-tool downloads through Terrapin to fix CFS violations

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,6 +62,8 @@ extends:
           useCppRestSDK: true
           cMakeRunArgs: '-A x64 -DVCPKG_MANIFEST_FEATURES=cpprestsdk'
           beforeBuild:
+          - powershell: eng\common\Configure-VcpkgAssetCache.ps1
+            displayName: Configure vcpkg asset cache (Terrapin)
           - powershell: |
               $root = if ($env:VCPKG_ROOT) { $env:VCPKG_ROOT } else { $env:VCPKG_INSTALLATION_ROOT }
               Write-Host "##vso[task.setvariable variable=VCPKG_ROOT]$root"
@@ -107,6 +109,8 @@ extends:
           useCppRestSDK: false
           cMakeRunArgs: '-A x64'
           beforeBuild:
+          - powershell: eng\common\Configure-VcpkgAssetCache.ps1
+            displayName: Configure vcpkg asset cache (Terrapin)
           - powershell: |
               $root = if ($env:VCPKG_ROOT) { $env:VCPKG_ROOT } else { $env:VCPKG_INSTALLATION_ROOT }
               Write-Host "##vso[task.setvariable variable=VCPKG_ROOT]$root"

--- a/eng/common/Configure-VcpkgAssetCache.ps1
+++ b/eng/common/Configure-VcpkgAssetCache.ps1
@@ -30,7 +30,7 @@ if ($terrapin) {
     # x-block-origin ensures vcpkg never falls back to the public internet if an asset is missing
     # from the cache, so a cache miss surfaces as a clear build failure rather than a silent
     # policy violation.
-    $assetSources = "x-script,$terrapin -b https://vcpkg.storage.devpackages.microsoft.io/artifacts/ -a true -u Environment -p {url} -s {sha512} -d {dst};x-block-origin"
+    $assetSources = "x-script,`\"$terrapin`\" -b https://vcpkg.storage.devpackages.microsoft.io/artifacts/ -a true -u Environment -p {url} -s {sha512} -d {dst};x-block-origin"
     Write-Host "##vso[task.setvariable variable=X_VCPKG_ASSET_SOURCES]$assetSources"
     Write-Host "Configured vcpkg asset cache using Terrapin at '$terrapin'."
 }

--- a/eng/common/Configure-VcpkgAssetCache.ps1
+++ b/eng/common/Configure-VcpkgAssetCache.ps1
@@ -1,0 +1,39 @@
+<#
+.SYNOPSIS
+Configures vcpkg to fetch build-time assets (e.g. the MSYS2 runtime/tools vcpkg bootstraps on
+Windows) through Microsoft's internal Terrapin asset cache instead of reaching out to public
+mirrors (mirror.msys2.org, ftp2.osuosl.org, us.mirrors.cicku.me, etc).
+
+Direct connections to those public mirrors violate the CFSClean2/CFSClean3 network isolation
+policies (SFI-ES4.2.4). See https://aka.ms/1espt-networkisolation for background.
+
+This only applies when running in the dnceng/internal project, since the Terrapin retrieval tool
+and its backing storage account are only available/authenticated on internal 1ES-hosted agents.
+On any other agent (e.g. public CI), this script is a no-op and vcpkg falls back to its default
+(public) download behavior.
+#>
+
+if ($env:SYSTEM_TEAMPROJECT -ne 'internal') {
+    Write-Host "Not running in the internal project; leaving vcpkg asset sources unconfigured."
+    return
+}
+
+$terrapin = (Get-Command TerrapinRetrievalTool.exe -ErrorAction SilentlyContinue).Source
+if (-not $terrapin) {
+    $fallbackPath = 'C:\local\Terrapin\TerrapinRetrievalTool.exe'
+    if (Test-Path $fallbackPath) {
+        $terrapin = $fallbackPath
+    }
+}
+
+if ($terrapin) {
+    # x-block-origin ensures vcpkg never falls back to the public internet if an asset is missing
+    # from the cache, so a cache miss surfaces as a clear build failure rather than a silent
+    # policy violation.
+    $assetSources = "x-script,$terrapin -b https://vcpkg.storage.devpackages.microsoft.io/artifacts/ -a true -u Environment -p {url} -s {sha512} -d {dst};x-block-origin"
+    Write-Host "##vso[task.setvariable variable=X_VCPKG_ASSET_SOURCES]$assetSources"
+    Write-Host "Configured vcpkg asset cache using Terrapin at '$terrapin'."
+}
+else {
+    Write-Host "##vso[task.logissue type=warning]TerrapinRetrievalTool.exe was not found on this agent. vcpkg will fall back to public mirrors, which may reintroduce CFS network isolation violations."
+}


### PR DESCRIPTION
## Summary
Fixes CFS network isolation violations (SFI-ES4.2.4) flagged against the `aspnet-SignalR-Client-Cpp` pipeline (dnceng/internal, pipeline 682).

## Root cause
Build [3023491](https://dev.azure.com/dnceng/internal/_build/results?buildId=3023491&view=results) showed `CFSClean2`/`CFSClean3` violations in the `Windows_Build_Test` and `Windows_Build_Test_With_CppRestSDK` jobs. Per the "Stop Network Isolation" task logs, vcpkg's own bootstrap step downloads its `msys2-runtime` and `pkgconf` tool packages directly from public mirrors:

```
Downloading msys2-mingw-w64-x86_64-pkgconf-... trying https://mirror.msys2.org/...
Downloading msys2-msys2-runtime-...             trying https://mirror.msys2.org/...
```

with fallback attempts hitting `ftp2.osuosl.org` / `us.mirrors.cicku.me`. This happens on every Windows vcpkg build (not just the cpprestsdk feature), since vcpkg needs msys2 to build several ports. Linux/macOS jobs are unaffected.

## Fix
Per the 1ES CFS remediation guidance ("Mirrors... If used for vcpkg, use Terrapin"), added `eng/common/Configure-VcpkgAssetCache.ps1`, run as a `beforeBuild` step on both Windows jobs. It:
- No-ops outside the internal project (public CI is unaffected/unchanged).
- Locates `TerrapinRetrievalTool.exe` on the agent.
- If found, sets `X_VCPKG_ASSET_SOURCES` to route vcpkg asset downloads through Terrapin + Microsoft's internal vcpkg asset cache (`vcpkg.storage.devpackages.microsoft.io`), with `x-block-origin` so vcpkg never falls back to public mirrors.
- If not found, logs a warning and leaves behavior unchanged (so we'll see clearly in CI logs whether Terrapin is present on our pool).

## Validation plan
This PR's own Windows job logs (and the next internal CI run's "Stop Network Isolation" step) will confirm whether Terrapin is present on our 1ES pool and whether the violations are resolved.
