### PR TITLE
Fix invalid PowerShell escaping in Configure-VcpkgAssetCache.ps1

### DIFF
--- a/eng/common/Configure-VcpkgAssetCache.ps1
+++ b/eng/common/Configure-VcpkgAssetCache.ps1
@@ -30,7 +30,7 @@ if ($terrapin) {
     # x-block-origin ensures vcpkg never falls back to the public internet if an asset is missing
     # from the cache, so a cache miss surfaces as a clear build failure rather than a silent
     # policy violation.
-    $assetSources = "x-script,`\"$terrapin`\" -b https://vcpkg.storage.devpackages.microsoft.io/artifacts/ -a true -u Environment -p {url} -s {sha512} -d {dst};x-block-origin"
+    $assetSources = "x-script,`"$terrapin`" -b https://vcpkg.storage.devpackages.microsoft.io/artifacts/ -a true -u Environment -p {url} -s {sha512} -d {dst};x-block-origin"
     Write-Host "##vso[task.setvariable variable=X_VCPKG_ASSET_SOURCES]$assetSources"
     Write-Host "Configured vcpkg asset cache using Terrapin at '$terrapin'."
 }


### PR DESCRIPTION
## Summary
Build [3030046](https://dev.azure.com/dnceng/internal/_build/results?buildId=3030046&view=results) failed on both Windows jobs after #119 merged. The new "Configure vcpkg asset cache (Terrapin)" step threw a PowerShell parser error:

```
Unexpected token '$terrapin`\" -b https://vcpkg.storage.devpackages.microsoft.io/artifacts/ ...' in expression or statement.
```

## Root cause
A "Copilot Autofix" commit (`9e74d97`) got merged into #119 alongside my original change. It attempted to quote `$terrapin` to guard against paths containing spaces, but used the invalid escape sequence `` `\" `` (backtick + backslash + quote). In PowerShell, a literal double quote inside a double-quoted string must be escaped as `` `" `` (backtick + quote) only — the extra backslash causes the string to terminate early, producing the parser error above.

## Fix
Corrected the escape sequence from `` `\" `` to `` `" `` in `eng/common/Configure-VcpkgAssetCache.ps1`. This is the minimal, single-line fix; the intent of quoting the path is preserved.
